### PR TITLE
Bug 1682428 - Create custom container for pioneer-debug 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,19 @@ jobs:
           command: docker build -t app:build jobs/example_job/
 
 
+  build-job-pioneer-debug:
+    docker:
+      - image: docker:stable-git
+    steps:
+      - checkout
+      - compare-branch:
+          pattern: ^jobs/pioneer-debug/
+      - setup_remote_docker:
+          version: 19.03.13
+      - run:
+          name: Build Docker image
+          command: docker build -t app:build jobs/pioneer-debug/
+
 workflows:
   docker-etl:
     jobs:
@@ -111,3 +124,16 @@ workflows:
             branches:
               only: main
 
+
+  job-pioneer-debug:
+    jobs:
+      - build-job-pioneer-debug
+      - gcp-gcr/build-and-push-image:
+          context: data-eng-airflow-gcr
+          path: jobs/pioneer-debug/
+          image: pioneer-debug_docker_etl
+          requires:
+            - build-job-pioneer-debug
+          filters:
+            branches:
+              only: main

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 venv/
+__pycache__/
+*.pyc

--- a/jobs/pioneer-debug/Dockerfile
+++ b/jobs/pioneer-debug/Dockerfile
@@ -1,0 +1,7 @@
+FROM gcr.io/deeplearning-platform-release/base-cpu
+LABEL maintainer="amiyaguchi@mozilla.com"
+
+# The home directory on a fresh ai-platform notebook is /home/jupyter, but it
+# will be overwritten by the installation scripts. We'll make a new directory.
+WORKDIR /app
+COPY . /app

--- a/jobs/pioneer-debug/README.md
+++ b/jobs/pioneer-debug/README.md
@@ -1,0 +1,3 @@
+# Template Job
+
+This is an example of a dockerized job.

--- a/jobs/pioneer-debug/README.md
+++ b/jobs/pioneer-debug/README.md
@@ -1,3 +1,4 @@
-# Template Job
+# pioneer-debug custom container
 
-This is an example of a dockerized job.
+See [bug 1682428](https://bugzilla.mozilla.org/show_bug.cgi?id=1682428) for
+details.

--- a/jobs/pioneer-debug/ci_job.yaml
+++ b/jobs/pioneer-debug/ci_job.yaml
@@ -1,0 +1,12 @@
+build-job-pioneer-debug:
+  docker:
+    - image: docker:stable-git
+  steps:
+    - checkout
+    - compare-branch:
+        pattern: ^jobs/pioneer-debug/
+    - setup_remote_docker:
+        version: 19.03.13
+    - run:
+        name: Build Docker image
+        command: docker build -t app:build jobs/pioneer-debug/

--- a/jobs/pioneer-debug/ci_workflow.yaml
+++ b/jobs/pioneer-debug/ci_workflow.yaml
@@ -1,0 +1,12 @@
+job-pioneer-debug:
+  jobs:
+    - build-job-pioneer-debug
+    - gcp-gcr/build-and-push-image:
+        context: data-eng-airflow-gcr
+        path: jobs/pioneer-debug/
+        image: pioneer-debug_docker_etl
+        requires:
+          - build-job-pioneer-debug
+        filters:
+          branches:
+            only: main

--- a/jobs/pioneer-debug/tutorials/README-storage.ipynb
+++ b/jobs/pioneer-debug/tutorials/README-storage.ipynb
@@ -1,0 +1,327 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Using Cloud Storage\n",
+    "\n",
+    "Cloud storage can be used to persist data across notebook instances. By default, each project is provisioned a google cloud storage bucket that\n",
+    "can be used across various services. In this notebook, we will persist artifacts from the notebook instance into cloud storage for future use. We will\n",
+    "also create a Javascript library that can be used within BigQuery."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configuration\n",
+    "\n",
+    "The bucket is found at `gs://${PROJECT}`. The project can be found using the `gcloud` command. We inject these values into the environment so we can move between Python and Bash."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "moz-fx-data-pion-nonprod-b3c9\n",
+      "notebook-amiyaguchi@moz-fx-data-pion-nonprod-b3c9.iam.gserviceaccount.com\n"
+     ]
+    }
+   ],
+   "source": [
+    "! gcloud config get-value project\n",
+    "! gcloud config get-value account"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "moz-fx-data-pion-nonprod-b3c9\n",
+      "notebook-amiyaguchi\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import subprocess\n",
+    "\n",
+    "def run(command: str) -> str:\n",
+    "    return subprocess.run(command.split(), stdout=subprocess.PIPE).stdout.strip().decode()\n",
+    "\n",
+    "os.environ[\"PROJECT\"] = run(\"gcloud config get-value project\")\n",
+    "os.environ[\"USER\"] = run(\"gcloud config get-value account\").split(\"@\")[0]\n",
+    "\n",
+    "! echo $PROJECT\n",
+    "! echo $USER"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using `gsutil rsync` for artifact storage\n",
+    "\n",
+    "The [`gsutil rsync` command](https://cloud.google.com/storage/docs/gsutil/commands/rsync) is used to sync the contents of two directories. We will synchronize the tutoral notebooks for storage into the project bucket.\n",
+    "\n",
+    "The tutorials are installed by default into the instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tutorials/storage\n",
+      "├── Cloud Storage client library.ipynb\n",
+      "├── resources\n",
+      "│   ├── downloaded-us-states.txt\n",
+      "│   └── us-states.txt\n",
+      "└── Storage command-line tool.ipynb\n",
+      "\n",
+      "1 directory, 4 files\n"
+     ]
+    }
+   ],
+   "source": [
+    "! tree tutorials/storage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we recursively sync these into cloud storage."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "WARNING: gsutil rsync uses hashes when modification time is not available at\n",
+      "both the source and destination. Your crcmod installation isn't using the\n",
+      "module's C extension, so checksumming will run very slowly. If this is your\n",
+      "first rsync since updating gsutil, this rsync can take significantly longer than\n",
+      "usual. For help installing the extension, please see \"gsutil help crcmod\".\n",
+      "\n",
+      "Building synchronization state...\n",
+      "Starting synchronization...\n",
+      "Copying file://tutorials/storage/Cloud Storage client library.ipynb [Content-Type=application/octet-stream]...\n",
+      "Copying file://tutorials/storage/Storage command-line tool.ipynb [Content-Type=application/octet-stream]...\n",
+      "Copying file://tutorials/storage/resources/downloaded-us-states.txt [Content-Type=text/plain]...\n",
+      "Copying file://tutorials/storage/resources/us-states.txt [Content-Type=text/plain]...\n",
+      "/ [4 files][ 17.3 KiB/ 17.3 KiB]                                                \n",
+      "Operation completed over 4 objects/17.3 KiB.                                     \n"
+     ]
+    }
+   ],
+   "source": [
+    "! gsutil rsync -r tutorials/storage/ gs://$PROJECT/$USER/test/artifacts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now they are persisted outside of this notebook instance. The notebook instance can be deleted without losing these artifacts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "gs://moz-fx-data-pion-nonprod-b3c9/notebook-amiyaguchi/:\n",
+      "\n",
+      "gs://moz-fx-data-pion-nonprod-b3c9/notebook-amiyaguchi/test/:\n",
+      "\n",
+      "gs://moz-fx-data-pion-nonprod-b3c9/notebook-amiyaguchi/test/artifacts/:\n",
+      "gs://moz-fx-data-pion-nonprod-b3c9/notebook-amiyaguchi/test/artifacts/Cloud Storage client library.ipynb\n",
+      "gs://moz-fx-data-pion-nonprod-b3c9/notebook-amiyaguchi/test/artifacts/Storage command-line tool.ipynb\n",
+      "\n",
+      "gs://moz-fx-data-pion-nonprod-b3c9/notebook-amiyaguchi/test/artifacts/resources/:\n",
+      "gs://moz-fx-data-pion-nonprod-b3c9/notebook-amiyaguchi/test/artifacts/resources/downloaded-us-states.txt\n",
+      "gs://moz-fx-data-pion-nonprod-b3c9/notebook-amiyaguchi/test/artifacts/resources/us-states.txt\n"
+     ]
+    }
+   ],
+   "source": [
+    "! gsutil ls -r gs://$PROJECT/$USER"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## BigQuery UDFs\n",
+    "\n",
+    "Cloud storage can be used to store [Javascript libraries that are called by BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions#including-javascript-libraries). These libraries can be compiled wasm code for performing moderately complex tasks. First we define a function `addOne` into a library on the local disk."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "resources = Path(\".\") / \"resources\"\n",
+    "resources.mkdir(exist_ok=True, parents=True)\n",
+    "\n",
+    "(resources / \"addOne.js\").write_text(\"\"\"\n",
+    "    (function() { addOne = function(x) { return x + 1}; }())\n",
+    "\"\"\".strip())\n",
+    "\n",
+    "! cat resources/addOne.js"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we copy this file into the storage bucket."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! gsutil rsync -r resources/ gs://$PROJECT/$USER/test/resources/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can use this function in BigQuery by defining the library as an option within a user defined function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4.140000000000001\n"
+     ]
+    }
+   ],
+   "source": [
+    "from google.cloud import bigquery\n",
+    "\n",
+    "client = bigquery.Client()\n",
+    "query = f\"\"\"\n",
+    "CREATE TEMP FUNCTION addOne(a FLOAT64)\n",
+    "  RETURNS STRING\n",
+    "  LANGUAGE js\n",
+    "  OPTIONS (\n",
+    "    library=[\"gs://{os.environ['PROJECT']}/{os.environ['USER']}/test/resources/addOne.js\"]\n",
+    "  )\n",
+    "  AS\n",
+    "'''\n",
+    "    // Use the function defined in the library function\n",
+    "    return addOne(a);\n",
+    "''';\n",
+    "\n",
+    "SELECT addOne(3.14);\n",
+    "\"\"\"\n",
+    "\n",
+    "for row in client.query(query):\n",
+    "    print(row.f0_)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cleanup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removing gs://moz-fx-data-pion-nonprod-b3c9/notebook-amiyaguchi/test/artifacts/Cloud Storage client library.ipynb#1596067736046955...\n",
+      "Removing gs://moz-fx-data-pion-nonprod-b3c9/notebook-amiyaguchi/test/artifacts/Storage command-line tool.ipynb#1596067736124013...\n",
+      "Removing gs://moz-fx-data-pion-nonprod-b3c9/notebook-amiyaguchi/test/artifacts/resources/downloaded-us-states.txt#1596067736224044...\n",
+      "Removing gs://moz-fx-data-pion-nonprod-b3c9/notebook-amiyaguchi/test/artifacts/resources/us-states.txt#1596067736300602...\n",
+      "/ [4 objects]                                                                   \n",
+      "==> NOTE: You are performing a sequence of gsutil operations that may\n",
+      "run significantly faster if you instead use gsutil -m rm ... Please\n",
+      "see the -m section under \"gsutil help options\" for further information\n",
+      "about when gsutil -m can be advantageous.\n",
+      "\n",
+      "Removing gs://moz-fx-data-pion-nonprod-b3c9/notebook-amiyaguchi/test/resources/addOne.js#1596067740924127...\n",
+      "/ [5 objects]                                                                   \n",
+      "Operation completed over 5 objects.                                              \n"
+     ]
+    }
+   ],
+   "source": [
+    "! gsutil rm -r gs://$PROJECT/$USER/test"
+   ]
+  }
+ ],
+ "metadata": {
+  "environment": {
+   "name": "common-cpu.m54",
+   "type": "gcloud",
+   "uri": "gcr.io/deeplearning-platform-release/base-cpu:m54"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/jobs/pioneer-debug/tutorials/README.ipynb
+++ b/jobs/pioneer-debug/tutorials/README.ipynb
@@ -1,0 +1,1025 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Getting Started with Pioneer\n",
+    "\n",
+    "This notebook is intended to get you familiar with the Pioneer Analysis environment with best practices for querying and saving datasets. The notebook environment is secured, so only **you** will have access to this particular notebook. You can, however, export the notebook. We will cover the basics of the `bq` command-line tool, working with BigQuery within the notebook environment, and how to share your work with other people on your team.\n",
+    "\n",
+    "Note that Notebook instances do *not* have access to the wider internet."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PING mozilla.org (63.245.208.195) 56(84) bytes of data.\n"
+     ]
+    }
+   ],
+   "source": [
+    "! timeout 10 ping mozilla.org"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `bq` basics and schemas\n",
+    "\n",
+    "You will not have access to the standard BigQuery console for querying data. To navigate the BigQuery project, the `bq` command-line tool will be your primary interface. In Jupyter, the bang prefix (i.e. `!`) will run a command in the default shell. Run `bq` or `bq --help` to get a list of available commands or reference [Using the bq command-line tool](https://cloud.google.com/bigquery/docs/bq-command-line-tool) for more details.\n",
+    "\n",
+    "Show details about the current project."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Project moz-fx-data-pion-nonprod-b3c9\n",
+      "\n",
+      "  friendlyName   \n",
+      " --------------- \n",
+      "  pioneer-debug  \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "! bq show"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "List the available datasets in this project. The study dataset corresponds to the namespace defined in [`mozilla/mozilla-pipeline-schemas`](https://github.com/mozilla-services/mozilla-pipeline-schemas/tree/generated-schemas/schemas). This contains read-only views of pings that have been ingested during the study. The `analysis` dataset is for storing and sharing tables derived from study pings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    datasetId    \n",
+      " --------------- \n",
+      "  analysis       \n",
+      "  pioneer_debug  \n"
+     ]
+    }
+   ],
+   "source": [
+    "! bq ls"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     tableId      Type                   Labels                   Time Partitioning   Clustered Fields  \n",
+      " --------------- ------ ---------------------------------------- ------------------- ------------------ \n",
+      "  debug_v1        VIEW   source_dataset_id:pioneer_debug_stable                                         \n",
+      "                         schemas_build_id:202006140144_d5ead7a                                          \n",
+      "  debug_v1_live   VIEW   source_dataset_id:pioneer_debug_live                                           \n",
+      "                         schemas_build_id:202006140144_d5ead7a                                          \n",
+      "  errors          VIEW                                                                                  \n"
+     ]
+    }
+   ],
+   "source": [
+    "! bq ls pioneer_debug"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The study table contains partitions with full days of deduplicated data. These are mapped directly from `mozilla/mozilla-pipeline-schemas`, taking on the form `{document_type}_v{document_version}`. The `{table_id}_live` table contains up-to-date pings ingested from the last 5-10 minutes with limited retention. Finally, the errors table contains pings that have been rejected due to invalid schemas.\n",
+    "\n",
+    "To view the schema for a table, use the `bq show` command."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Table moz-fx-data-pion-nonprod-b3c9:pioneer_debug.debug_v1\n",
+      "\n",
+      "   Last modified                   Schema                   Type   Expiration                   Labels                  \n",
+      " ----------------- --------------------------------------- ------ ------------ ---------------------------------------- \n",
+      "  16 Jun 19:21:41   |- additional_properties: string        VIEW                source_dataset_id:pioneer_debug_stable  \n",
+      "                    |- datetime: timestamp                                      schemas_build_id:202006140144_d5ead7a   \n",
+      "                    |- document_id: string                                                                              \n",
+      "                    +- metadata: record                                                                                 \n",
+      "                    |  +- geo: record                                                                                   \n",
+      "                    |  |  |- city: string                                                                               \n",
+      "                    |  |  |- country: string                                                                            \n",
+      "                    |  |  |- db_version: string                                                                         \n",
+      "                    |  |  |- subdivision1: string                                                                       \n",
+      "                    |  |  |- subdivision2: string                                                                       \n",
+      "                    |  +- header: record                                                                                \n",
+      "                    |  |  |- date: string                                                                               \n",
+      "                    |  |  |- dnt: string                                                                                \n",
+      "                    |  |  |- x_debug_id: string                                                                         \n",
+      "                    |  |  |- x_pingsender_version: string                                                               \n",
+      "                    |  +- user_agent: record                                                                            \n",
+      "                    |  |  |- browser: string                                                                            \n",
+      "                    |  |  |- os: string                                                                                 \n",
+      "                    |  |  |- version: string                                                                            \n",
+      "                    |  +- isp: record                                                                                   \n",
+      "                    |  |  |- db_version: string                                                                         \n",
+      "                    |  |  |- name: string                                                                               \n",
+      "                    |  |  |- organization: string                                                                       \n",
+      "                    |- normalized_app_name: string                                                                      \n",
+      "                    |- normalized_channel: string                                                                       \n",
+      "                    |- normalized_country_code: string                                                                  \n",
+      "                    |- normalized_os: string                                                                            \n",
+      "                    |- normalized_os_version: string                                                                    \n",
+      "                    |- sample_id: integer                                                                               \n",
+      "                    |- submission_timestamp: timestamp                                                                  \n",
+      "                    |- pioneer_id: string                                                                               \n",
+      "                    |- study_name: string                                                                               \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "! bq show pioneer_debug.debug_v1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Querying Study Tables and Destination Tables\n",
+    "The BigQuery tables available in the study dataset are views on [Mozilla's Data Platform standard BigQuery table layout](https://docs.telemetry.mozilla.org/cookbooks/bigquery/querying.html#table-layout-and-naming). These will be the primary source for many analyses.\n",
+    "\n",
+    "The study tables are _historical ping tables_ that are populated once a day. They never contain partial days of data and are deduplicated by `document_id`. These are partitioned by `submission_timestamp` and require the use of a partition filter (i.e. `WHERE` clause on `submission_timestamp`) to query. The _live ping tables_ have the same structure, but slightly different semantics in terms of availability.\n",
+    "\n",
+    "To query in the notebook, use [the `%%bigquery` magic](https://googleapis.dev/python/bigquery/latest/magics.html). "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>submission_timestamp</th>\n",
+       "      <th>study_name</th>\n",
+       "      <th>document_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2020-06-01 07:33:25.110699+00:00</td>\n",
+       "      <td>pioneer-v2-example</td>\n",
+       "      <td>f4b4ff12-357f-1348-a5da-77f150207a71</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2020-06-01 20:01:31.908587+00:00</td>\n",
+       "      <td>pioneer-v2-example</td>\n",
+       "      <td>937814bc-6efd-4ae9-974a-95fc386f8766</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2020-06-01 20:04:32.444225+00:00</td>\n",
+       "      <td>pioneer-v2-example</td>\n",
+       "      <td>517b53cc-e11e-cf41-8bde-c4fa8d2dbde5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2020-06-01 15:40:01.567397+00:00</td>\n",
+       "      <td>pioneer-v2-example</td>\n",
+       "      <td>2299ce62-1a9a-e443-b62e-f18f066f1740</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2020-06-01 20:01:31.916964+00:00</td>\n",
+       "      <td>pioneer-v2-example</td>\n",
+       "      <td>08cfb78b-a704-44ea-afa1-dc861ee6e916</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              submission_timestamp          study_name  \\\n",
+       "0 2020-06-01 07:33:25.110699+00:00  pioneer-v2-example   \n",
+       "1 2020-06-01 20:01:31.908587+00:00  pioneer-v2-example   \n",
+       "2 2020-06-01 20:04:32.444225+00:00  pioneer-v2-example   \n",
+       "3 2020-06-01 15:40:01.567397+00:00  pioneer-v2-example   \n",
+       "4 2020-06-01 20:01:31.916964+00:00  pioneer-v2-example   \n",
+       "\n",
+       "                            document_id  \n",
+       "0  f4b4ff12-357f-1348-a5da-77f150207a71  \n",
+       "1  937814bc-6efd-4ae9-974a-95fc386f8766  \n",
+       "2  517b53cc-e11e-cf41-8bde-c4fa8d2dbde5  \n",
+       "3  2299ce62-1a9a-e443-b62e-f18f066f1740  \n",
+       "4  08cfb78b-a704-44ea-afa1-dc861ee6e916  "
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%bigquery\n",
+    "SELECT \n",
+    "    submission_timestamp, \n",
+    "    study_name, \n",
+    "    document_id\n",
+    "FROM\n",
+    "    pioneer_debug.debug_v1\n",
+    "WHERE\n",
+    "    date(submission_timestamp) > date_sub(current_date, interval 30 day)\n",
+    "LIMIT 5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Queries can be stored directly into a destination table in the analysis dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>submission_timestamp</th>\n",
+       "      <th>study_name</th>\n",
+       "      <th>document_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2020-06-01 20:01:31.922322+00:00</td>\n",
+       "      <td>pioneer-v2-example</td>\n",
+       "      <td>55c93f79-e0a6-432a-bf25-5b9d08df214b</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2020-06-16 11:19:50.158683+00:00</td>\n",
+       "      <td>pioneer-v2-example</td>\n",
+       "      <td>58133145-e671-446c-a55f-c6c5b4d51e7a</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2020-06-01 20:01:31.918860+00:00</td>\n",
+       "      <td>pioneer-v2-example</td>\n",
+       "      <td>e45f8954-5387-4bdb-86ad-da4c28408bd5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2020-06-05 19:35:18.110024+00:00</td>\n",
+       "      <td>pioneer-v2-example</td>\n",
+       "      <td>bec24acf-f9b4-7e42-a529-a5ff568fb59c</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2020-05-27 23:20:18.424399+00:00</td>\n",
+       "      <td>pioneer-v2-example</td>\n",
+       "      <td>d8a7fee8-db56-844b-a93e-eb886b1f169a</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>80</th>\n",
+       "      <td>2020-06-01 19:33:09.087377+00:00</td>\n",
+       "      <td>pioneer-v2-example</td>\n",
+       "      <td>06812c34-1061-e04b-867b-58b872be800d</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>81</th>\n",
+       "      <td>2020-05-27 23:20:18.102596+00:00</td>\n",
+       "      <td>pioneer-v2-example</td>\n",
+       "      <td>6d32301b-6ce6-e343-87e1-b86cb981ac20</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>82</th>\n",
+       "      <td>2020-05-30 21:26:23.489637+00:00</td>\n",
+       "      <td>pioneer-v2-example</td>\n",
+       "      <td>5e67c507-9696-5449-9899-36f3c885ee6f</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>83</th>\n",
+       "      <td>2020-05-28 06:12:29.741101+00:00</td>\n",
+       "      <td>pioneer-v2-example</td>\n",
+       "      <td>27de08c9-2d50-ea4f-bfe0-fefec533dd52</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>84</th>\n",
+       "      <td>2020-06-17 16:39:55.684919+00:00</td>\n",
+       "      <td>pioneer-v2-example</td>\n",
+       "      <td>523f4f8d-75e4-174f-a461-bc8fffb98509</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>85 rows × 3 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "               submission_timestamp          study_name  \\\n",
+       "0  2020-06-01 20:01:31.922322+00:00  pioneer-v2-example   \n",
+       "1  2020-06-16 11:19:50.158683+00:00  pioneer-v2-example   \n",
+       "2  2020-06-01 20:01:31.918860+00:00  pioneer-v2-example   \n",
+       "3  2020-06-05 19:35:18.110024+00:00  pioneer-v2-example   \n",
+       "4  2020-05-27 23:20:18.424399+00:00  pioneer-v2-example   \n",
+       "..                              ...                 ...   \n",
+       "80 2020-06-01 19:33:09.087377+00:00  pioneer-v2-example   \n",
+       "81 2020-05-27 23:20:18.102596+00:00  pioneer-v2-example   \n",
+       "82 2020-05-30 21:26:23.489637+00:00  pioneer-v2-example   \n",
+       "83 2020-05-28 06:12:29.741101+00:00  pioneer-v2-example   \n",
+       "84 2020-06-17 16:39:55.684919+00:00  pioneer-v2-example   \n",
+       "\n",
+       "                             document_id  \n",
+       "0   55c93f79-e0a6-432a-bf25-5b9d08df214b  \n",
+       "1   58133145-e671-446c-a55f-c6c5b4d51e7a  \n",
+       "2   e45f8954-5387-4bdb-86ad-da4c28408bd5  \n",
+       "3   bec24acf-f9b4-7e42-a529-a5ff568fb59c  \n",
+       "4   d8a7fee8-db56-844b-a93e-eb886b1f169a  \n",
+       "..                                   ...  \n",
+       "80  06812c34-1061-e04b-867b-58b872be800d  \n",
+       "81  6d32301b-6ce6-e343-87e1-b86cb981ac20  \n",
+       "82  5e67c507-9696-5449-9899-36f3c885ee6f  \n",
+       "83  27de08c9-2d50-ea4f-bfe0-fefec533dd52  \n",
+       "84  523f4f8d-75e4-174f-a461-bc8fffb98509  \n",
+       "\n",
+       "[85 rows x 3 columns]"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%bigquery --destination_table analysis.my_table\n",
+    "SELECT \n",
+    "    submission_timestamp, \n",
+    "    study_name, \n",
+    "    document_id\n",
+    "FROM\n",
+    "    pioneer_debug.debug_v1\n",
+    "WHERE\n",
+    "    date(submission_timestamp) > date_sub(current_date, interval 30 day)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can see the table in our analysis dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  tableId    Type    Labels   Time Partitioning   Clustered Fields  \n",
+      " ---------- ------- -------- ------------------- ------------------ \n",
+      "  my_table   TABLE                                                  \n"
+     ]
+    }
+   ],
+   "source": [
+    "! bq ls analysis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Table moz-fx-data-pion-nonprod-b3c9:analysis.my_table\n",
+      "\n",
+      "   Last modified                  Schema                 Total Rows   Total Bytes   Expiration   Time Partitioning   Clustered Fields   Labels  \n",
+      " ----------------- ------------------------------------ ------------ ------------- ------------ ------------------- ------------------ -------- \n",
+      "  24 Jun 21:05:23   |- submission_timestamp: timestamp   85           5610                                                                      \n",
+      "                    |- study_name: string                                                                                                       \n",
+      "                    |- document_id: string                                                                                                      \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "! bq show analysis.my_table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The resulting table is available from any other notebook environment within the project. This is the primary mechanism for sharing intermediate results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>submission_timestamp</th>\n",
+       "      <th>study_name</th>\n",
+       "      <th>document_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2020-06-01 20:01:31.922322+00:00</td>\n",
+       "      <td>pioneer-v2-example</td>\n",
+       "      <td>55c93f79-e0a6-432a-bf25-5b9d08df214b</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2020-06-16 11:19:50.158683+00:00</td>\n",
+       "      <td>pioneer-v2-example</td>\n",
+       "      <td>58133145-e671-446c-a55f-c6c5b4d51e7a</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2020-06-01 20:01:31.918860+00:00</td>\n",
+       "      <td>pioneer-v2-example</td>\n",
+       "      <td>e45f8954-5387-4bdb-86ad-da4c28408bd5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2020-06-05 19:35:18.110024+00:00</td>\n",
+       "      <td>pioneer-v2-example</td>\n",
+       "      <td>bec24acf-f9b4-7e42-a529-a5ff568fb59c</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2020-05-27 23:20:18.424399+00:00</td>\n",
+       "      <td>pioneer-v2-example</td>\n",
+       "      <td>d8a7fee8-db56-844b-a93e-eb886b1f169a</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              submission_timestamp          study_name  \\\n",
+       "0 2020-06-01 20:01:31.922322+00:00  pioneer-v2-example   \n",
+       "1 2020-06-16 11:19:50.158683+00:00  pioneer-v2-example   \n",
+       "2 2020-06-01 20:01:31.918860+00:00  pioneer-v2-example   \n",
+       "3 2020-06-05 19:35:18.110024+00:00  pioneer-v2-example   \n",
+       "4 2020-05-27 23:20:18.424399+00:00  pioneer-v2-example   \n",
+       "\n",
+       "                            document_id  \n",
+       "0  55c93f79-e0a6-432a-bf25-5b9d08df214b  \n",
+       "1  58133145-e671-446c-a55f-c6c5b4d51e7a  \n",
+       "2  e45f8954-5387-4bdb-86ad-da4c28408bd5  \n",
+       "3  bec24acf-f9b4-7e42-a529-a5ff568fb59c  \n",
+       "4  d8a7fee8-db56-844b-a93e-eb886b1f169a  "
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%bigquery\n",
+    "SELECT * FROM analysis.my_table LIMIT 5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Working with Pandas DataFrames\n",
+    "\n",
+    "Queries from BigQuery can be serialized into a Pandas dataframe for further analysis, and written back into BigQuery. Lets generate a plot of distinct documents per day."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bigquery my_pandas_df\n",
+    "SELECT\n",
+    "    *\n",
+    "FROM\n",
+    "    analysis.my_table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>submission_timestamp</th>\n",
+       "      <th>study_name</th>\n",
+       "      <th>document_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2020-06-01 20:01:31.922322+00:00</td>\n",
+       "      <td>pioneer-v2-example</td>\n",
+       "      <td>55c93f79-e0a6-432a-bf25-5b9d08df214b</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2020-06-16 11:19:50.158683+00:00</td>\n",
+       "      <td>pioneer-v2-example</td>\n",
+       "      <td>58133145-e671-446c-a55f-c6c5b4d51e7a</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2020-06-01 20:01:31.918860+00:00</td>\n",
+       "      <td>pioneer-v2-example</td>\n",
+       "      <td>e45f8954-5387-4bdb-86ad-da4c28408bd5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2020-06-05 19:35:18.110024+00:00</td>\n",
+       "      <td>pioneer-v2-example</td>\n",
+       "      <td>bec24acf-f9b4-7e42-a529-a5ff568fb59c</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2020-05-27 23:20:18.424399+00:00</td>\n",
+       "      <td>pioneer-v2-example</td>\n",
+       "      <td>d8a7fee8-db56-844b-a93e-eb886b1f169a</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              submission_timestamp          study_name  \\\n",
+       "0 2020-06-01 20:01:31.922322+00:00  pioneer-v2-example   \n",
+       "1 2020-06-16 11:19:50.158683+00:00  pioneer-v2-example   \n",
+       "2 2020-06-01 20:01:31.918860+00:00  pioneer-v2-example   \n",
+       "3 2020-06-05 19:35:18.110024+00:00  pioneer-v2-example   \n",
+       "4 2020-05-27 23:20:18.424399+00:00  pioneer-v2-example   \n",
+       "\n",
+       "                            document_id  \n",
+       "0  55c93f79-e0a6-432a-bf25-5b9d08df214b  \n",
+       "1  58133145-e671-446c-a55f-c6c5b4d51e7a  \n",
+       "2  e45f8954-5387-4bdb-86ad-da4c28408bd5  \n",
+       "3  bec24acf-f9b4-7e42-a529-a5ff568fb59c  \n",
+       "4  d8a7fee8-db56-844b-a93e-eb886b1f169a  "
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_pandas_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZMAAAENCAYAAADKcIhSAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3deXxU9bn48c+TFTIJkI0AYU0AEVkEEVREcK11o7jcVm2rbdVqtdW2t96ut9pF29rl3t5arVpb/dWtBa3W2mpLBQQtO8qmQlgDyCRsSQjZn98f50wYQwJJZs7MnMnzfr3yInPmzMz3CZM88/1+z/f5iqpijDHGRCIl3g0wxhjjf5ZMjDHGRMySiTHGmIhZMjHGGBMxSybGGGMilhbvBsRDQUGBDh8+PN7NMMYYX1m5cmWlqha2d1+PTCbDhw9nxYoV8W6GMcb4iohs7+g+G+YyxhgTMUsmxhhjImbJxBhjTMQsmRhjjImYb5KJiAwRkddFZKOIrBeRO93j94jILhFZ435dEu+2GmNMT+Onq7magK+q6ioRyQFWisg/3Pt+oao/jWPbjDGmR/NNz0RV96jqKvf7amAjUBzfVpnuqmts5uGFZTQ0tcS7KcaYKPBNMgknIsOBScBS99AdIvKOiDwuIrkdPOYWEVkhIisqKipi1FLTkSWbK/nR395l2db98W6KMSYKfJdMRCQbmAfcpapVwENAKXAqsAf4WXuPU9VHVHWKqk4pLGx3AaeJob1V9QDsO1wf55YYY6LBV8lERNJxEslTqvo8gKruVdVmVW0BHgWmxrONpnOC1XUA7KtpiHNLjDHR4JtkIiIC/BbYqKo/Dzs+MOy0OcC6WLfNdF2w2umRHKi1ZGJMMvDT1VzTgU8Ba0VkjXvsm8C1InIqoMA24PPxaZ7pimCV2zM5bMnEmGTgm2SiqosBaeeuV2LdFhO5UM9kvw1zGZMUfDPMZZJL0J2A3289E2OSgiUTE3MtLUpljZtMbM7EmKRgycTE3P7aBppalNQUsZ6JMUnCkomJudAQ14iCAAdqG2hu0Ti3yBgTKUsmJuZCa0zGDMhBFQ7aUJcxvmfJxMRc6Equkwf2AWytiTHJwJKJibnQGpMxA3IAWwVvTDKwZGJiLlhdT59eaQzo2wuwy4ONSQaWTEzMBavq6d+nF/mBTMBWwRuTDCyZmJgLVtfRPyeT3EA6AAcsmRjje5ZMTMwFq+vpn5NJZloqOZlp1jMxJglYMjExpapOMunjzJfkBjJszsSYJGDJxMRU1ZEmGppa6J/jzJfkWTIxJilYMjExtdddsBjqmeRbMjEmKVgyMTEVKqViPRNjkoslExNToVIqbZOJqtXnMsbPLJmYmAqVUgkNc+UFMmhobqGmvimezTLGRMiSiYmpYFU9WRmpZGc6m3zmBTIAOHC4MZ7NMsZEyJKJianQgsWQ/Gwnmew7XB+vJhljosCSiYkpZ8Fir9bbuVlOMrFJeGP8zZKJiamK6noK+4T1TKw+lzFJwZKJiam9VXUUhfVM8rJDcyaWTIzxM0smJmZq6puobWimf1jPJJCRSkZaig1zGeNzlkxMzIQ2xQqfgBcR8rIybJjLGJ+zZGJipnWNSdgwF9gqeGOSgSUTEzNHFyxmfuh4frYlE2P8zpKJiZn2hrnAeibGJANLJiZmKqrryUhLoW/v9A8dz82yZGKM3/kmmYjIEBF5XUQ2ish6EbnTPZ4nIv8QkU3uv7nxbqtpX7C6nsLsTETkQ8fzAxnU1DdR39Qcp5YZYyLlm2QCNAFfVdWTgTOA20VkLPB1YL6qjgLmu7dNAtpbVUdRm/kSOLrWxHonxviXb5KJqu5R1VXu99XARqAYmA084Z72BPCx+LTQnEjbUioh+QFLJsb4nW+SSTgRGQ5MApYCRaq6B5yEA/Tv4DG3iMgKEVlRUVERq6aaMMGqumOu5AKrz2VMMvBdMhGRbGAecJeqVnX2car6iKpOUdUphYWF3jXQtKuusZmquqZjruSCo5WDLZkY41++SiYiko6TSJ5S1efdw3tFZKB7/0AgGK/2mY5VdLBgESAvVOyxxpKJMX7lm2QiziVAvwU2qurPw+56CbjB/f4G4MVYt82cWGi73sJ2hrn69U4nReBArSUTY/wqLd4N6ILpwKeAtSKyxj32TeBHwB9F5HPADuCaOLXPHEewKtQzOTaZpKQIuVafyxhf800yUdXFgHRw9/mxbIvpur2tq9+PHeYCyA1ksN+GuYzxLd8Mcxl/C1bXk5oirZcBt2UlVYzxN0smJiZCq99TUtrvXOYHMthvcybG+JYlExMTwer6dteYhFjPxBh/s2RiYiJYVdfu5HtIXiCDA7UNNLdoDFtljIkWSyYmJiqq6ynsYPIdnGSiCgdtqMsYX7JkYjzX2NzCvsMNJ+yZgK01McavLJkYz1XWtL/DYrh8WwVvjK9ZMjGe21vVcSmVkNyAs2GWTcIb40+WTIznQtv1treXSUhrz8SSiTG+ZMnEeC54nCKPIaGeyQFLJsb4kiUT47lgdT0iUJDd/up3gMy0VHIy06xnYoxPWTIxnquoriM/kEFa6vHfbrm2cNEY37JkYjwXrDr+GpMQWwVvjH9ZMjGec/Z+73jyPSTfkokxvmXJxHguWH38Uioh1jMxxr8smRhPNbcoFSco8hgSSiaqVp/LGL+xZGI8te9wPS0KRX06N2fS0NxCTX1TDFpmjIkmSybGU8fbrret1vpchxs9bZMxJvosmRhPVbgLFjtzNVe+uw5l3+F6T9tkjIk+SybGU8Hq0N7vJ+6Z5GY5ycQm4Y3xH0smxlOhYa7CTl0abPW5jPErSybGU8Hqevr2TqdXeuoJz83Ltp6JMX5lycR4au8JtusNF8hIJSMtxYo9GuNDlkyMp4KdXGMCICLkZWXYMJcxPmTJxHiqorqeok5cyRViq+CN8SdLJsYzqs7q98JO9kzAuTzYeibG+I8lE+OZg7WNNDS3HHdTrLbyAhk2Z2KMD1kyMZ45usNi53smuVk2zGWMH/kqmYjI4yISFJF1YcfuEZFdIrLG/boknm00R3VlwWJIfiCDmvom6puavWqWMcYDvkomwO+Bi9s5/gtVPdX9eiXGbTIdaK3L1YkijyG21sQYf/JVMlHVRcD+eLfDdM7ebvZMwJKJMX7jq2RyHHeIyDvuMFhueyeIyC0iskJEVlRUVMS6fT1SsKqeQEYqgcy0Tj/G6nMZ40/JkEweAkqBU4E9wM/aO0lVH1HVKao6pbCwMJbt67Eqqus7tY9JuHwb5jLGl3yfTFR1r6o2q2oL8CgwNd5tMo5gdV2nCjyGywsVe6yxZGKMn/g+mYjIwLCbc4B1HZ1rYssppdK1nknf3umkCByotWRijJ90fjA7AYjIM8AsoEBEyoHvArNE5FRAgW3A5+PWQNNKVQlW1Xdp8h0gNUXoZ/W5jPEdXyUTVb22ncO/jXlDzAnV1DdxpLG5y8kE3PpcNsxljK/4fpjLJKbW1e9dqMsVYsUejfEfSybGE3urQmtMujZnAs5ak/02Z2KMr1gyMZ6o6EZdrpBc65kY4zuWTIwnulNKJSQ/kMGB2gaaWzTazTLGeMSSifFEsLqOzLQU+vTq+jUeeYEMVOGgDXUZ4xuWTIwnQtv1ikiXH5vn1ueytSbG+IclE+MJZ41J14e44GgysVXwxviHJRPjiWB1Xbcm3+FoMrFJeGP8w5KJ8UR3Vr+H5Ifqc1kyMcY3LJmYqDvS0Ex1fVO3ruQCyA2kA9he8Mb4iCUTE3Xd2a43XGZaKtmZadYzMcZHLJmYqDtaSqV7PROwkirG+I0lExN1rQsWu9kzAUsmxviNJRMTdZEOc4Fbn8uSiTG+YcnERF2wup60FGndz707rGdijL9YMjFRF6yqpzAnk5SUrq9+DwklE1Wrz2WMH1gyMVEXyYLFkLxABg3NLdTUN0WpVcYYL1kyMVHn9Ey6fyUX2Cp4Y/zGkomJumB1HUXd2GExXH62JRNj/MSSiYmqhqYWDtQ2drvIY0ho8t6SiTH+YMnERFVFTff3fg9n9bmM8RdLJiaqglWRrzEByLNhLmN8xZKJiarWUioRDnMFMlLJSEuxYo/G+IQlExNVR+tyRdYzERHysjJsmMsYn7BkYqIqWFWHiFMOJVK2Ct4Y/7BkYqIqWFVPfiCTtNTI31r52dYzMcYvLJmYqIrGGpOQvECGzZkY4xOWTExUBau7v11vW7lZNsxljF/4KpmIyOMiEhSRdWHH8kTkHyKyyf03N55t7OmcZBLZlVwh+YEMauqbqG9qjsrzGWO846tkAvweuLjNsa8D81V1FDDfvW3ioLlF2VdTH/GVXCG21sQY//BVMlHVRcD+NodnA0+43z8BfCymjeqEusZmNu6pinczPLevpp4WjXzBYki+FXs0xjd8lUw6UKSqewDcf/u3d5KI3CIiK0RkRUVFRUwb+Lsl27jkl2/w7gfJnVBCa0wirRgcYvW5jPGPZEgmnaKqj6jqFFWdUlhYGNPXXvh+EFX4zcItMX3dWNsbKqUSpWEuqxxsjH8kQzLZKyIDAdx/g3Fuz4fUNjSxavtBsjJSeent3ZQfqI13kzxztJRKtC4Ndos91lgyMSbRJUMyeQm4wf3+BuDFOLblGMu3HaChuYXvXj4WAR57Y2u8m+SZYFVomCs6yaRv73RSBA7UWjIxJtH5KpmIyDPAW8BJIlIuIp8DfgRcKCKbgAvd2wljyeZKMlJTuGJiMbNPLebZ5TuSdtgmWF1HblY6mWmpUXm+1BShn9XnMsYXfJVMVPVaVR2oqumqOlhVf6uq+1T1fFUd5f7b9mqvuHpjUyWnDculd0Yqt84soa6xhSfe3BbvZnkimmtMQvICGey3YS5jEp6vkonfVNbUs3FPFWePKgBgVFEOF5xcxBNvbaO2oSm+jfNAsDp6a0xCrNijMf5gycRDb5btA2D6yILWY7fNKuFgbSPPLtsZr2Z5pqKqLmrzJSH5gQz225yJMQnPkomHlmyqpE+vNMYX9209dtqwPE4fnstjb2yhsbkljq2LrpYW9WSYK9d6Jsb4giUTj6gqizdXclZpAakp8qH7bptVyu5Ddby0ZnecWhd9B2obaGrRqF0WHJIfyOBAbQPNLRrV5zXGRJclE49s21fLroNHmD6q4Jj7zj2pPycV5fCbRWW0JMkfyWjtsNhWXiADVThoQ13GJDRLJh5ZvLkSgLNHHptMRIRbZ5Xw/t4a/vVuQq2x7LZQMinqE/2rucDWmhiT6CyZeGTJpkqK+/VmeH5Wu/dfNmEQxf168/DCshi3zBvBUCmVKA9zhZKJrYI3JrFZMvFAc4vyZlklZ48sQETaPSc9NYWbZoxgxfYDLN+WUEtjuuVoKRVveiY2CW9MYrNk4oF1uw5RVdfU7nxJuI+fPoTcrHQeXuD/3klFdT05mWn0zojO6veQ/FB9LksmxiQ0SyYeCM2XnFWaf9zzsjLSuOGs4cx/N8h7H1THommeCVbXURjlyXeA3EA6gO0Fb0yCs2TigcWbKjl5YB8Ksk/8x/WGM4fTOz2V3yzyd+9kb1X09n4Pl5mWSnZmmvVMjElwlkyi7EhDMyu3H+DskcfvlYTkBjL4xNQhvLRmN7sOHvG4dd4JVtdFfb4kxEqqGJP4LJlE2fJt+2lobuHsUZ3fgOumGSUAPPaGPzfPUlWCHvVMwJKJMX5gySTKQiXnTx+e2+nHFPfrzRUTB/Hssp2+nBuoqmuivqkl6mtMQvIDVobemERnySTK3thUyeRh/cjKSOvS4z4/s5Qjjc088dY2T9rlpYrq6G7X21ZuIMOXSdaYnsSSSRTtq6lnw56qdle9n8hJA3I4f0x/nnjTf+Xpo73DYlv57jCXauxLz8TjNY3xI0smUdReyfmuuG1WKQdqG3luub/K03u1YDEkL5BBQ3MLNfWxT7I3PbGCmQ+8zotrdiVNHTVjvGDJJIqWbK4kp1caEwb369bjpwzPY8qwXB57Y6uvytMHPR7mitcq+NU7DjD/3SBVRxq589k1XP6rxSx8v8J6K8a0w5JJlKgqb2yq5KzS/GNKznfFrTNL2XXwCC+/45/y9Hur6umVnkJOZtfmiTorXsnk4YVl9O2dzsK7z+UXH5/IoSON3PD4Mq57dClv7zwY07YYk+gsmUTJdrfkfHfmS8KdN6Y/o4uyeXjBFt98Ag5titVRHbJIxSOZbA7W8NqGvXz6zGH06ZXOnEmDmf/VmXz38rG8t7ea2Q8u4QtPrWRLRU3M2mRMIrNkEiWhEirdnS8JSUkRPn9OKe/treb19/xRnj5YVefZGhOIT32uRxaVkZGawg1nDW89lpmWymemj2Dh12bxpfNHseC9Ci78xSK+8fxa9rpVk43pqSyZRMmSzZUM6tuLEQWBiJ/rilMHMahvLx5e4I9FjBXV9Z6tMQHIy45tz+SDQ3W8sHoXHz99SLslcXJ6pfOVC0ez8Gvn8slpQ/nTip3MfOB1fvL3dzl0pDEmbTQm0VgyiQKn5Pw+zh7Vccn5rnDK05ewbNt+Vm5P/PL0wep6zy4LBghkpJKRmhKztSaPL9lKi8LNbmWCjhTmZHLv7HHM/+pMLho7gF8vKGPmA6/zyKIy6hqbY9JWYxKFNzOmPcy6XYc4dKQx4iGucJ+YOoRf/msTDy3YwmM35EXteY/n0UVb2LinqkuPaVGlpr7Jsyu5wNmZMi9Gq+AP1Tby1L+3c+n4gQzJa39js7aG5Qf45bWTuOWcEn7y6nvc98q7/H7JNm45p4Q5kwfTt3e6x602Jv4smUTB0ZLz0UsmWRlpXD9tKA8tKOODQ3UM6OvdMBLAjn21/PCVjRRkZ3R5T5KSwgBnlHSusGV3xao+1x+WbudwQzO3zizt8mPHFfflyc9O5c3NlTzw2nvc85cN/Ojv73LZhEFcN20ok4b08+wiBWPizZJJFCzZXMmYATlRH+q55rQhPPh6Gc+vLucLs0ZG9bnbmreqHBF46Y6zGdSvt6ev1R352d73TOoam/ndkq3MHF3I2EF9uv08Z40s4IWRBazbdYinlu7gxTW7mLuynDEDcrh+2lBmTyqmTy/rrZjkYnMmETrS0MyKbQciviS4PcMLAkwZlsu8leWeXibc0qI8v7qc6aUFCZlIwOmZeD1n8qeV5VTWNHSrV9KeccV9uf/K8Sz71gX8cM44UlOE77y4nmk/nM9/zX2HNTsP+ubyb2NOxJJJhFZsD5Wcj34yAbj6tMGUVRxmjYeL5JZt28/O/Ue4+rTBnr1GpHKzvB3mampu4dFFWzh1SD/OKInuHFV2ZhrXTxvGy188mxdvn84VEwfx0tu7+diDS7j0l4v5w7+3x6VUjDHRlDTJRES2ichaEVkjIiti9bqLN1WSnipMHeHNJPklEwaSmZbCvFXlnjw/wLyV5WRnpvGRUwZ49hqRyg9kUFPfRH2TN1dJ/W3dB+zYX8utM0s9m9cQESYO6cePr57A0m+dz/dnn0KLKt/+8zqm/vCffOP5d1hbfsiT1zbGa8k2Z3KuqlbG8gUXb65k8tDcLpec76w+vdK5eNwAXlqzm29fOpZe6V2bHD+R2oYmXlm7h8smDOryxHssha81Gdg3ukNxqsrDC8soKQxw0diiqD53R/r0SudTZw7nk2cMY/XOgzy9dAcvrN7FM8t2Mr64L9dNG8oVEwcR8KhEjTHRljQ9k3jYf7iB9bu7V3K+K66aPJiquibmb4z+ivi/r/uAww3NXJXAQ1zg9EzAm4WLb2yqZP3uKj5/TgkpEdRV6w4RYfLQXH56zUSWfvMC7r3iFBqaWvjG82uZdt98vvXCWtbvtt6KOaqxuYUtFTUcrE2sPX6S6WOPAq+JiAK/UdVHvH7BN8ucTpBX8yUh00cWMKBPL+au3MmlEwZG9bnnrixnaF5Wl3aGjIfcLO+SycMLyyjqk8nHJhVH/bm7om/vdG44azifPnMYq3Yc4KmlO5i7spynlu5g4pB+XD91KJdNHOhZL9gklv2HG9hSUcOWisOUVdRQVnGYLZU17NhXS1OLUlIY4G93ziAzLTFGFJLpXTldVXeLSH/gHyLyrqouCt0pIrcAtwAMHTo0Ki8YKjk/vrhvVJ6vI6kpwpzJxTyyaAvB6rqo7RtSfqCWt7bs467zRyf8+od8j0qqvL3zIG+W7eObl4xJmF9KEeG0YXmcNiyP/75sLM+v2sXTy3Zw97x3+P7LG5gzuZjrpg1lzIDuX75sEkNDUws79h92EkXFYSd5VDrJ42Dt0dI8GakpDMvPYlT/bC4+ZQCZaan84p/v89CCMu66YHQcIzgqaZKJqu52/w2KyAvAVGBR2P2PAI8ATJkyJeLrMUMl588sySct1fvRwqsmD+ahBWW8uHo3N59z/DIfnfXCql2owpWT4/uJvDPyQsUea6KbTB5eWEZOrzSunRqdDxjR1i8rg8+ePYLPTB/O8m0HeHrpdp5dvpMn39rO5KH9uG7aMC4dPzCh57t6OlVl3+GG1h5GqLexpfIwO/bX0hy26VphTiYlBQE+Om4gpYUBSguzKSkMMDg365itLTYFq/n162VcMXEQJYXZsQ7rGEmRTEQkAKSoarX7/UXA97x8zR37ayk/cIRbovSH/URG9s/m1CH9mLuynJtmjIi4J6GqzFtVzhkleZ0uGxJPfXunkyJwIIrjxFsqavj7+g/4wqxSchJ8EaGIc8Xg1BF5fPdwA/NWlfP00h3855/e5nt/Wc+Vkwdz/bShjCrKiXdTe6z6pma276tlizskVRZKGhU1VNUdvfQ7Iy2FEfkBTh6Yw6XjB1JSGKDETRpdWcz635eNZeF7FXz7z+t46qZpcR9dSIpkAhQBL7g/zDTgaVX9u5cvGK2S811x9WmD+faf17F+dxXjIhxaW7n9ANv21XLHeaOi1DpvpaYI/bKiuwr+0Te2kJ6awo1njYjac8ZCbiCDm2aU8LmzR/DvLft5etkOnlq6nd+/uY3Th+dy7dShXDJ+YNSv/DPOh7CKmnrKgs78RfjQ1M79tYTv7FzUJ5OSgmwunziotYdRWpjNoH69I9pAL6R/n17cffFJfOfF9fx5zS7mTIrvRTRJkUxUdQswMZavGSo5XxKFkvOddfmEQXzv5Q3MXVkecTKZt6qcrIxUPjoucdeWtJUXyGB/lIa5glV1zFu5i2umDPa04rGXRIQzS/M5szSffTVjmbuynGeW7eArf3ybe/+ygasmD+a6aUMZ2T/+QyB+U9fYzLZ9R+cxykJJo+Iw1WELTDPTUigpzGZccV9mu8NNJYUBRhQEYtLbvW7aMOau2sUPXt7IuSf1p597oUo8JEUyibVQyfkLTy6Kadeyb1Y6F44t4sU1u/jmJSeTkda9uZq6xmZefnsPHx030FfrGKJZ7PG3S7bS1NISs2FKr+VnZ/L5maXcPKOEt7bs4+mlO3jyrW08vmQrU0fkcf20oVw8bkDCXGSQCFSVYHU9ZcEayioPf+jKqV0HjxBe6WZg316UFAaYM7mYkoKjw1KD+vaO+eXk4VJThPvmjOOKXy3hx39/l/uvnBC3tvjnL0kCWb/7EAdrGz2/JLg9V08ezF/f2cO/3g1ycTd7Fa+u/4Dq+iauOi3xJ97D5Qcy2BSMfJvcqrpGnv73Di4ZP5Bh+bHrWcZCSoowfWQB00cWUFFdz59W7uTZZTu589k15Galc/Vpg7l26tCEmLCNlSMNzWytdIal2g5PHW44WlGhd3oqJYUBJg3N5arJg1uHpUYUBBL6Q9cpg/ry2enDefSNrVw5eTCnD4/NlhVtJe5PKIF5UXK+s2aMKqAwJ5N5q8q7nUzmriynuF9vzhjhbdn4aMuNUs/kD//eTnV9U9QKOiaqwpxMvjBrJLeeU8qSskqeXrqD3y3ZxqNvbOXMknyumzaUj5wyoNs93ESiquw5VOdeJVUTduXUYXYdPPKhc4v79aakMMA1U4Y4k98FTi9jQJ9ece1lROKuC0bz13f28K0X1vLyF2fE5f/Ukkk3eFVyvjPSUlOYM6mYxxdvZV9NPfntbCt7PB8cqmPJ5kruOHek735x8gMZHKhtoLlFuz2BWdfYzOOLtzFjVEHE805+kZIizBhVyIxRhQSr6viTO7fyxWdWkx/I4Oopg7n29KEMj+H8X3fVNjR9KFFscYentlYepjaslxHISKWkMJspw3P5j4IhlPZ3ksaIgkBSXkYdyEzj3tnjuPnJFTy2eIvnW1a0x5JJF9U1NrN82wE+fcawuLXhqsmDeWTRFl5cs5vPnt21K5GeX11Oi8KVkxO7fEp78gIZqMLB2oYuJ9GQ51ftorKmnttmnhrl1vlD/z69uP3ckdw2s5RFmyp4eukOHntjK79ZuIWzRxZw3bShXDi2iPQYrJ3qSEuLsvvQkWMW8W2pOMyeQ3Wt54mEehnZTB2RR0lhNqXufEZRn8y4XyobaxeOLeKisUX8cv4mLp8wKOaX/Fsy6aIV2w7Q0NTC9DjMl4ScNCCH8cV9mbuyvEvJRFWZt7Kc04fn+uJTaFt5YfW5upNMmluURxaVMWFwX84s9dcQX7SlpAizTurPrJP688GhOv64YifPLtvBF55aRUF2Jv8xxZlb8fIPUk19E1vDFvI5k+CH2VpZQ11jS+t5OZlprbt5lhQEKO3vDEsNzw/Y5c9t3HPFKVz484V858V1/O7G02OaUC2ZdNEbmyuckvNxmuQKuWpyMff8ZQMbdld1elfANTsPUlZxmJtn+PMKprwIiz3+fd0HbNtXy0PXT+5xn1qPZ0DfXnzp/FHcfu5IFr4f5OmlO3h4YRkPLSzj7JEFXD9tGOef3L9bvZXmFmX3wSOtPYujw1M17K2qbz0vRWBwbhalhQHOKs1vncsoLQxQmNPzehndNahfb7584Wh+8NeNvLL2g6jX8jseSyZdtGRzJZOG5sb96o4rTi3mh69sZN6qcsYOGtupx8xbVU6v9BQuieEbLJoiSSahMvMjCgJclMD7tsRTaopw3pgizhtTxO6DR3hu+U6eW76TW/+wkv45mfzHlCF8YuoQBuce21upqms8OiwVNgm+pfIwDU1Hexl9eqVRUpjN9JEFlBY6yaKkMJth+Vl22XKU3HjWcF5YvYt7/7KeGaMLYrZFtCWTLgiVnNYHY3UAABUsSURBVP9yAhRWywtkcN6Y/ry4Zhdf/+iYE35qrGts5qU1u/nIKQN8u/94fqg+VzeSyYL3K1i76xD3Xzk+KquPk13oE+4XzxvJ6+9V8MyyHTy4YDMPLtjMzNGFnFGS31o6ZEvlYSqqj/YyUlOEIbm9KS3MZsaoAmdNhjs8lR/IsF6Gx9JSU7hvzng+9usl/OzV97h39rjYvG5MXiVJLN+2H1XvS8531tWnDeHV9XtZ9H4F5598/E2d5m8MUlXXlNBb855IbsBJgl3pmQSr6vif+Zt4bvlOivv1Zk6cy8z7TVpqCheOLeLCsUXsOniE55bt4NnlO1nwXgX9stIpKQgwc3RhWLmQAEPzAklxubGfTRzSj0+fMYwn/72dOZMHc+qQfp6/piWTLrhobBHzvzqTYQlSGHHWSYXkBzKYu7L8hMlk7sqdDOjTKy5rY6IlMy2V7My0TiWTQ0ca+c3CMh5fspXmFuWT04Zyx3mjbMI2AsX9evOVi07iS+ePoqa+Ka6lO8yJffUjJ/G3dR/wzefX8tId0z2vbm4fH7pARCgtzI5JyfnOSE9NYfapxczfGOTAcf7ABqvqWLSpkisnF/t+iOdEJVXqGpt5dNEWZj7wOr9eUMZHThnA/K/M4t7Z43xbgyvRpKWmWCLxgT690vnu5aewYU8Vv39zm+evlxh/FU23XXVaMQ3NLfzlnd0dnvPnNbtobtGE35q3MzpKJs0tyh9X7OS8ny7gh69sZMLgfrz8xbP5309MYmh+YvQkjYm1S8YPYNZJhfz8H++zu00lgGizZOJzpwzqy8kD+zBvZXm79ztrS3YxaWg/SpOgHlN+4MNl6FWVf2zYy0f/dxF3z32HwpxMnr55Gk9+dmqPWeFuTEdEhO/PHkeLKve8tN7T17JkkgSumlzM2+WH2LS3+pj71u2q4r291VzlwxXv7ckNZLQO6S3ftp9rHn6Lm59cQVOz8uvrJ/Pn26f7el7ImGgbkpfFneeP5rUNe/nHhr2evY4lkyTwsUnFpKUIc1cd2zuZt6qcjLQULp8wKA4tiz6nZ1LPTU8s55qH32LH/lrumzOeV798DpeMH2iXnRrTjptmjOCkohy+++I6DoftxxJNlkySQEF2JrNOKuSFVbtoaj66QKyhqYUX1+ziwrFF9M3y59qStgqyM2lsVpZu3c/XPnISC792LtdNGxrXWlLGJLr01BTuu3Icuw/V8T//fN+T17BLg5PE1acN5p8bgyzeXMmsk/oD8K93gxyobfT12pK2rpxcTEZaCldMHERuwK4oMqazThuWx1cuHM3kobmePL8lkyRx7pj+9MtKZ+7K8tZkMndlOYU5mcyI4T71XsvPzuSGs4bHuxnG+NKXzh/l2XPb2ECSyExLZfbEQby2YS+HjjRSWVPPgveCXDmpOGHWxRhjkpf9lUkiV502mIamFl5+ZzcvrtlNU5KsLTHGJD4b5koi44v7Mroom3kry6lrbGHC4L6MLsqJd7OMMT2A9UySiIhw1eTBrNpxkA17qpJmbYkxJvFZMkkycyYVkyKQnipcMTE51pYYYxKfDXMlmf59evHx04eSmZZil84aY2LGkkkSuv/K8fFugjGmh7FhLmOMMRGzZGKMMSZilkyMMcZELGmSiYhcLCLvichmEfl6vNtjjDE9SVIkExFJBR4EPgqMBa4VkbHxbZUxxvQcSZFMgKnAZlXdoqoNwLPA7Di3yRhjeoxkSSbFwM6w2+XusVYicouIrBCRFRUVFTFtnDHGJLtkWWfS3vZ6+qEbqo8AjwCISIWIbAcKgErvmxcXfojND22MRDLHl8yxQXLHF0lswzq6I1mSSTkwJOz2YGB3RyeraiGAiKxQ1Skety0u/BCbH9oYiWSOL5ljg+SOz6vYkmWYazkwSkRGiEgG8AngpTi3yRhjeoyk6JmoapOI3AG8CqQCj6vq+jg3yxhjeoykSCYAqvoK8EoXH/aIF21JEH6IzQ9tjEQyx5fMsUFyx+dJbKKqJz7LGGOMOY5kmTMxxhgTR5ZMjDHGRKxHJBMRaW8dijFRYe8vk2hEJD3Wr5m0yUQcXxaRwZqEE0MiMkpEesW7HSfi1k1Luj+49v7yNxGZICLZ8W5HtLnvy3uAu0K3Y/XaSZlMROTTwOvAJKAqmf6QichsESkDvgc8JiJ58W5Te0TkRhFZDdwZ77ZEm72//EtErheRd4B7gefcdWlJQUQ+ifO+/DTwSYBYftBJumQiItOB3wP/qaqfVtWq0A/U77/07i/2TcB1qnotEAS+JSKj49uyDxORMcAXgJeBc0SkRFVVRHz/frP3l3+JyEeBzwO3qeocoBS43L3Pt/93IpIqIp8DbgbuVtUSYJeInBLLdvj+lxsgvLuqqktwVsSf7N73dRG5XESy/Tgc0U5XXIAW9/tngauAS+L9CUtEckLfq+q7OJ+OfgFsAO5wj7e0/+jE1ia2ZHt/5bQ9RAK+v7orNMzqWqCq56jqEhHpC2xxzxGf/t+lAqhqM/Ciqs5U1WUicjJQTfs1Cz3j+2QiIncDC0TkJyLyGffwF4AnRGQN0A/4IvCA+4nZN8Jie0BEPgEcANYCN4hILjAFWAEMoE2V5Bi38+vAahH5sYjc6B5+T1X3Ay8ApSJyjnuur95zbWL7nHs4Wd5fodh+IiLXuf9fCff+6i4R+R7w3yJS6B6qd48X4SxwPoiTLP34fxeKrT+Aqla6x0VVNwLDgVPdY7H5nVNVX34B+TjDDX90f2hXA0uBYe79twOnud8XAn8GPhLvdncztmvc2PKBEuDnwF+Bp4BTgAXA8Di19TxgETACOBfYA0wIuz8bZzLwqbBjqfH+GUcQ2+Sw99cUP76/jhPbaJyqsAnz/upmbJnAN4DtOB9mLmrnnL7uv3k4dfwuiXe7oxFb6HcL+BLwcCzb5udyKoeB11T1aQBxSspfjPMJaruqPhg6UVUrRGQ/zhvHDzqKrURVlwNfEZEBqvqBe385Tmzb4tDWdGC1qm4FtorI/wL3A5e69x8G5gIni8j3cX4ZfgOUxaGtXdVebPcBF/v8/QXHxvZ/wM9U9XIS6/3VHY0483W/xBliPVdENrmxAqCqh9x/94tIEMiNS0u77rixqTPkBU4v7JA7FyQagyFmXw05hFPVOuAvYYeacD7Fl4efJyJ5IvIzYALOWHfC6yC2icDesHM+EJEhIvIgTgJ9L7atbJUF5IcuI1XVHwEDReQa97YCdcB44DagQlX9kEig/dj6h2IDf76/XG1juw8oFpGPu7cT5f3VZe4fzvdV9TDwHM6WFFNFJBOOTra7/3c/xfm74Yv/u07EFpojehf4jDpiMlfpi2QiIrPCxj1bqWp12M18IKiqO8IeV4IziZgOzFTVzZ43tou6G5vrQZwqyZe6by7PiMinRGR82+Oq+gLOVTGXhR3+CfCVsNv3A+uBoar6gJft7I7uxiYiI4BnSOz3V1djuyvs9q+I0furu44TX7377zZgMTATGBP2uAk4w8ih/7v3Y9LgLuhObGE9kzeB+0QkLWZXqsV7DPB4XzhDO4uAR4E+YccFSNEPjxGejTsuD3wEmOV+nx/vODyI7SL3+0AM2jkReBtnTmBim3Zmut9/wo1luHt7KE6iy3Fv94r3z9uD2DKAXkBevOPwILZs93ZWvOPoZnxtf3/6AP8HXAd8CrjMPV4Y7ziiHNsngTnxanfCzZmExviAj+OMrX9OVf8Ufr86P0V1ex77ca7KOAfIEJGHcIYcvg6gqvtiHEKHPIgtFp8WLwEeVGfb41ZuO+vddj4HjAW+Lc5CxcuBber2rtQZtktEkcTW4J6ejLHVuOfWxrjNXXG8+D70+6OqVSKyCSdR7sOZnEZVK2Lc5s6KOLZ4SKhhrtAfU3XG+HYDTwKb3fuuEZHBON1SRORbwBJguvvwU4BpwLuqOl1V34h5AMfhl9ja6RKPAUITsV8WkYtFpJ97+7+AZTg9p58BvwOmAvNV9Vav2thdFps/Y4NuxfcmcKY4xuAM3z2gqiPV2fsoYSRLbAmzn4k4OyWeD7yB84f2APA54DM4V1qsxdnMa6+q3uqe/5SqHnAffxmwWFUPxqP9x+OX2MLauRD4k6ruEpH7ca68uhTnDZ6LM47+A+BM4LlQO93nSNWj47YJw2LzZ2wQeXzuRQapMerJd0lSxRav8bXwL2AOztUU5+J8SnoQ55r3QcCPgEnuefk4XbnwccT0eLc/GWLroJ1DccbV/4XzyQecN/W/gMvDHpuK+8EkEb8sNn/GFoX40uLd/p4UW6IMc00DHlLV14F7cK5nv1tVdwP3qOpqaJ3/eB73mnB36KgxLi3uPL/E1rad24FvqOqzOJ+O0kWkSJ1Pr2/iXAkUamezuu/wBGWx+TM2iCy+pji1ubOSKraYJpO2Y4Nht7fgXI2Aqm7HWWORIyJXaNjkrYh8B2f+YKN7bsL8Ivglti608yWgUETOBh7AWSz1DbedV+N0y/36f2CxJVBskNzxJXNs4WLdM/nQhi1hP5S5QK2IzHZv78Ep4TAWQERmiMjrOMNDV6nqXhKPX2LrSjv/BZzl9p7ux1kIlQVcEOpRJRiLzZ+xQXLHl8yxtYrJpcEicibOQq/dIvIbnCKAzSKS5nbXDuDUmblNRF5S1UPiVMvt7T7FNuB2Vd0Qi/Z2hV9i62Y7A0AAnLITwMNetrG7LDZ/xgbJHV8yx9Yez3sm4lS1/BVOlc59OJslfRYgbNyvN/AqTmZ+REQG4Ww81OCetzNBE4kvYotGOxOVxebP2CC540vm2DrUdkY+2l/AhcAz7vcBnBXcLwNj3GM/wPmBTsIpJvcDnGGgX5Pg1WX9Eptf2mmx9ZzYkj2+ZI6tw5g9+CF+DPgmTj0fcMpzbwJK3dt5wHeBH+OMBT4dui/sORKyjINfYvNLOy22nhNbsseXzLF19itqw1wiUigif8YZI9wP/E5ErlanZME8nA2EwCkPMt/94fZS1etUtUzCNnDRBCvj4JfY/NLO7rDYAB/GBskdXzLH1lXRnDMpBZaosy3mw8BXOVo59hlgjIhcoE45kX1AEUd3PkvRxN7S1S+x+aWd3WGx+TM2SO74kjm2Lonoai4R+TSwA6fOz0pgq3s8FWfv7/XuqWtxSsH/j4h8DKd8gOBeMpeIP1C/xOaXdnaHxQb4MDZI7viSObZIdDmZuAtuBuCM+bXg1JC5GbhTVfeKW+NHnE3t+0LrD+337hUOX8cpZHazJlgdLb/E5pd2dofF5s/YILnjS+bYoqYrEywcraE/GviD+30aTj3959uc8yTwH+73A8KeIyOakz7R+vJLbH5pp8XWc2JL9viSObZofnWqZyIiacD3gFQReQVnQ5ZmcK6ZFpEv4SzMmamqC92H1eDsLf094EoRuVhVy/XoPhAJwS+x+aWd3WGx+TM2SO74kjk2L5xwAl5EZuKMC+bi7L/xfZyaMeeKyFRoLQ/wPZxiZaGxw8/ilAvoA5yrquXHPHmc+SU2v7SzOyw2f8YGyR1fMsfmmU508WYAnwq7/WvgNuBGYKV7LAVnPPGPwDCcKxz+B5gc765XMsTml3ZabD0ntmSPL5lj8+xn1okfahaQydExweuB+93v1wBfdL+fAjwb74C6+IbxRWx+aafF1nNiS/b4kjk2r75OOMylqrWqWq9Hd2G7EAjtnfwZ4GQReRnnmuqV0O42lAnJL7H5pZ3dYbH5MzZI7viSOTavdPrSYHc8UHEW3bzkHq7GKSEwDtiqqrsgcevtd8Qvsfmlnd1hsfkzNkju+JI5tmjrygr4FpzFNpXABDcrfwdoUdXFoR+oT/klNr+0szssNv9K5viSObaokq4kUxE5A2f7yDeB36nqb71qWKz5JTa/tLM7LDb/Sub4kjm2aOpqMhkMfAr4uarWe9aqOPBLbH5pZ3dYbP6VzPElc2zR1KVkYowxxrQn1nvAG2OMSUKWTIwxxkTMkokxxpiIWTIxxhgTMUsmxhhjImbJxBhjTMQsmRjTDhG5R0T+M4LH3yrO9q5decwgEZnb3dfsxPPfKCK/OsE5s0TkLK/aYJJXRHvAG2Pap6oPd+Mxu4GrPWhOV8zC2eDpzTi3w/iM9UxMjyEiARH5q4i8LSLrROTjIrJNRArc+6eIyIKwh0wUkX+JyCYRudk9Z5aILBSRP4rI+yLyIxG5XkSWichaESl1z2vt2YjIl0Rkg4i8IyLPusdmisga92u1iOSIyHARWefe30tEfuc+52oROdc9fqOIPC8if3fb9ZMTxPwZt50Lgelhxy8XkaXuc/9TRIpEZDhwK/Blt10zRKRQROaJyHL3a3oHL2V6OOuZmJ7kYmC3ql4KICJ9gR8f5/wJwBlAAFgtIn91j08ETgb2A1uAx1R1qojcCXwRuKvN83wdGKGq9SLSzz32n8DtqrpERLKBujaPuR1AVceLyBjgNREZ7d53KjAJqAfeE5H/U9WdbRsvIgOBe4HTgEPA68Bq9+7FwBmqqiJyE3C3qn5VRB4GalT1p+5zPA38QlUXi8hQ4FU3dmM+xHompidZC1wgIj8WkRmqeugE57+oqkdUtRLnD/FU9/hyVd3j1mkqA14Le/7h7TzPO8BTIvJJoMk9tgT4uTj7iPdT1aY2jzkb+H8AqvousB0IJZP5qnpIVeuADTi7/LVnGrBAVSvU2YP8ubD7BgOvisha4GvAKR08xwXAr0RkDU4J9j4iktPBuaYHs2RiegxVfR/nU/pa4H4R+W+cP+6h34NebR/Swe3wYn8tYbdbaL+3fynwoPvaK0UkTVV/BNwE9Ab+7fY+wh1vo6Xw12/u4DXbtrmt/wN+parjgc9zbOwhKcCZqnqq+1WsqtXHeT3TQ1kyMT2GiAwCalX1D8BPgcnANpw/8gBXtXnIbHfuIh9nYnp5N14zBRiiqq8DdwP9gGwRKVXVtar6Y2AF0DaZLMLZKhZ3eGso8F4XX34pMEtE8kUkHbgm7L6+QGgvjhvCjlcD4T2P14A7wuI5tYttMD2EJRPTk4wHlrlDNt8CfoAzp/C/IvIGzqf8cMuAvwL/Br7vXm3VVanAH9zhpNU48w8HgbvciwDeBo4Af2vzuF8Dqe7jngNu7Gr5c1XdA9wDvAX8E1gVdvc9wJ/cuCvDjv8FmBOagAe+BExxLx7YgDNBb8wxrAS9McaYiFnPxBhjTMTs0mBjkoCILAUy2xz+lKqujUd7TM9jw1zGGGMiZsNcxhhjImbJxBhjTMQsmRhjjImYJRNjjDER+/8xdmFshdw1cQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "my_pandas_df[\"submission_date\"] = my_pandas_df.submission_timestamp.dt.floor(\"d\")\n",
+    "my_pandas_df.groupby(\"submission_date\").document_id.nunique().plot()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can accomplish the same task by pushing most of the work onto BigQuery. This is preferable because it reads less rows into memory and requires less work from the notebook instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bigquery my_aggregated_df\n",
+    "SELECT\n",
+    "    TIMESTAMP_TRUNC(submission_timestamp, day) as submission_date,\n",
+    "    COUNT(DISTINCT document_id) as n_documents\n",
+    "FROM\n",
+    "    analysis.my_table\n",
+    "GROUP BY\n",
+    "    submission_date\n",
+    "ORDER BY\n",
+    "    submission_date"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZMAAAENCAYAAADKcIhSAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3dd3yV5fn48c+VDSeBTFbCCiCILBFBBQTqqNu6vtZVR9U6a2uHdnzr6LCtrbX91kq1df3qakGLs7ZSmSojgLIEDAQIIElYSQjZ1++P5znhEAJknPWcXO/XKy9ynvOcc+4rnOQ6930/93WLqmKMMcZ0RFykG2CMMcb7LJkYY4zpMEsmxhhjOsySiTHGmA6zZGKMMabDEiLdgEjIzs7WAQMGRLoZxhjjKQUFBWWqmtPSfZ0ymQwYMIClS5dGuhnGGOMpIrL5SPfZMJcxxpgOs2RijDGmwyyZGGOM6bBOOWdijIkOdXV1FBcXU11dHemmmAApKSnk5eWRmJjY6sd4JpmISF/gBaAX0Ag8paq/F5EHgVuAUvfUH6rqO5FppTGmLYqLi0lLS2PAgAGISKSbYwBVZdeuXRQXFzNw4MBWP84zyQSoB76jqstEJA0oEJH/uPf9TlV/E8G2GWPaobq62hJJlBERsrKyKC0tPfbJATwzZ6KqO1R1mft9BbAWyI1sq0x7Vdc1MH1uIbX1jZFuiokwSyTRpz3/J55JJoFEZABwIrDIPXSXiHwqIs+ISMYRHnOriCwVkaVtzbgm+BZ+XsYv3/2MxZt2R7opxpgg8FwyEZFUYCbwLVUtB54EBgFjgB3Ab1t6nKo+parjVHVcTk6LCzhNGO0srwFg1/6aCLfEGBMMnkomIpKIk0heVNXXAFR1p6o2qGoj8DQwPpJtNK1TUuFcvbOrsjbCLTGmfYqKihgxYkSkm9EqK1as4J13QntdkmeSiTiDeH8F1qrqYwHHewecdgmwKtxtM21XUuH0SPZUWTIxJtTCkUy8dDXXROA6YKWIrHCP/RC4SkTGAAoUAd+ITPNMW5SUuz2T/ZZMjOOhN1ezZnt5UJ9zeJ9uPHDhCUc9p6ioiHPPPZdJkybx4Ycfkpuby6xZs+jSpcth5xYUFHDTTTfRtWtXJk2a1HS8urqa22+/naVLl5KQkMBjjz3GtGnTaGho4L777uO9995DRLjlllu4++67m+oDZmdns3TpUr773e8yZ84cHnzwQTZt2sSOHTtYv349jz32GB9//DHvvvsuubm5vPnmmyQmJlJQUMC9995LZWUl2dnZPPfcc/Tu3ZupU6cyYcIEPvjgA/bu3ctf//pXJkyYwE9+8hMOHDjAggUL+MEPfkCvXr245557AGeyfd68eaSlpXXoZ+2ZnomqLlBVUdVRqjrG/XpHVa9T1ZHu8YtUdUek22qOzd8z2W3DXCYKbNiwgTvvvJPVq1eTnp7OzJkzWzzvxhtv5A9/+AMfffTRIcefeOIJAFauXMnLL7/M9ddfT3V1NU899RSbNm1i+fLlfPrpp1xzzTXHbEthYSFvv/02s2bN4tprr2XatGmsXLmSLl268Pbbb1NXV8fdd9/NjBkzmpLbj370o6bH19fXs3jxYh5//HEeeughkpKSePjhh7nyyitZsWIFV155Jb/5zW944oknWLFiBfPnz28xcbaVl3omJoaUuBPwu61nYlzH6kGE0sCBAxkzZgwAJ510EkVFRYeds2/fPvbu3cuUKVMAuO6663j33XcBWLBgAXfffTcAw4YNo3///qxfv57333+f2267jYQE509tZmbmMdty7rnnkpiYyMiRI2loaOCcc84BYOTIkRQVFbFu3TpWrVrFWWedBUBDQwO9ex8c7b/00kuPGgfAxIkTuffee7nmmmu49NJLycvLO2a7jsWSiQm7xkalrNJNJjZnYqJAcnJy0/fx8fEcOHDgsHNU9YjrL1T1iMdbekxCQgKNjc4aq+alZPxtiYuLIzExsenxcXFx1NfXo6qccMIJh/WOmj8+Pj6e+vr6Fs+5//77Of/883nnnXc45ZRTeP/99xk2bFiL57aWZ4a5TOzYXVVLfaMSHyfWMzGekZ6eTvfu3VmwYAEAL774YtN9p59+etPt9evXs2XLFoYOHcrZZ5/N9OnTm/6o797trKsaMGAABQUFAEccUjuSoUOHUlpa2pRM6urqWL169VEfk5aWRkVFRdPtwsJCRo4cyX333ce4ceP47LPP2tSGllgyMWHnH+IamO1jT1UtDY0tf6ozJto8++yz3HnnnZx66qmHzDPccccdNDQ0MHLkSK688kqee+45kpOTufnmm+nXrx+jRo1i9OjRvPTSSwA88MAD3HPPPUyePJn4+Pg2tSEpKYkZM2Zw3333MXr0aMaMGcOHH3541MdMmzaNNWvWMGbMGF599VUef/xxRowYwejRo+nSpQvnnntu238YzciRumexbNy4cWo7LUbOnHUl3PDsEi4Y1Zu3Pt1BwY/PJCs1+dgPNDFn7dq1HH/88ZFuhmlBS/83IlKgquNaOt96Jibs/FdyHd+7G2BrTYyJBTYBb8LOv8ZkWC/nuvZdlbUM7hHJFhlzqDvvvJOFCxcecuyee+7hxhtvjFCLop8lExN2JRU1dEtJoFf3FMAuD+7sjnaVVKT41410Vu2Z/rBhLhN2JeU19OiWQpbPmSexVfCdV0pKCrt27WrXHy8TGv7NsVJSUtr0OOuZmLArqaimR1oyGT5nS9A9lkw6rby8PIqLi9u8EZMJLf+2vW1hycSEXUlFDeP6Z5CcEE9acoL1TDqxxMTENm0Na6KXDXOZsFJVSiqcYS6ADF+SzZkYEwMsmZiwKj9QT219Iz3SnPmSTEsmxsQESyYmrHa6m2L5eyZZlkyMiQmWTExY+UupWM/EmNhiycSElX+73ubJxC4NNcbbLJmYsPKXUvEPc2X6kqhtaKSypuVS2cYYb7BkYsKqpLyGrknxpCa7mwX5kgDYs78uks0yxnSQJRMTVv4Fi35ZqU4y2bW/JlJNMsYEgSUTE1YlFTX0SDtYpiGjq5NMbBLeGG+zZGLCqrSihpxuAT0Tq89lTEywZGLCamd5NT0DeiaZqf45E0smxniZJRMTNpU19VTVNtAjoGfiS4onKSHOhrmM8ThLJiZs/JtiBU7AiwiZXZNsmMsYj7NkYsKmaY1J2qH7JNgqeGO8z5KJCZuDCxaTDzmelWrJxBivs2RiwqalYS6wnokxscCSiQmb0ooakhLi6N4l8ZDjGV0tmRjjdZ5JJiLSV0Q+EJG1IrJaRO5xj2eKyH9EZIP7b0ak22paVlJRQ05qMiJyyPEsXxKVNfXU1DdEqGXGmI7yTDIB6oHvqOrxwCnAnSIyHLgfmK2qQ4DZ7m0ThXaWV9Oz2XwJHFxrYr0TY7zLM8lEVXeo6jL3+wpgLZALXAw87572PPCVyLTQHEvzUip+WT5LJsZ4nWeSSSARGQCcCCwCeqrqDnASDtDjCI+5VUSWisjS0tLScDXVBCgprz7sSi6w+lzGxALPJRMRSQVmAt9S1fLWPk5Vn1LVcao6LicnJ3QNNC2qrmugvLr+sCu54GDlYEsmxniXp5KJiCTiJJIXVfU19/BOEent3t8bKIlU+8yRlR5hwSJApr/YY6UlE2O8yjPJRJxLgP4KrFXVxwLuegO43v3+emBWuNtmjs2/XW9OC8Nc6V0SiRPYU2XJxBivSoh0A9pgInAdsFJEVrjHfgj8Evi7iHwd2AJcEaH2maMoKff3TA5PJnFxQobV5zLG0zyTTFR1ASBHuPuMcLbFtN3OptXvhw9zAWT4kthtw1zGeJZnhrmMt5VU1BAfJ02XATdnJVWM8TZLJiYs/Kvf4+Ja7lxm+ZLYbXMmxniWJRMTFiUVNS2uMfGznokx3mbJxIRFSXl1i5Pvfpm+JPZU1dLQqGFslTEmWCyZmLAoragh5wiT7+AkE1XYa0NdxniSJRMTcnUNjezaX3vMngnYWhNjvMqSiQm5ssqWd1gMlGWr4I3xNEsmJuR2lh+5lIpfhs/ZMMsm4Y3xJksmJuT82/W2tJeJX1PPxJKJMZ5kycSEXMlRijz6+XsmeyyZGONJlkxMyJVU1CAC2aktr34HSE6IJy05wXomxniUJRMTcqUV1WT5kkiIP/rbLcMWLhrjWZZMTMiVlB99jYmfrYI3xrssmZiQc/Z+P/Lku1+WJRNjPMuSiQm5koqjl1Lxs56JMd5lycSEVEOjUnqMIo9+/mSiavW5jPEaSyYmpHbtr6FRoWe31s2Z1DY0UllTH4aWGWOCyZKJCamjbdfbXFN9rv11IW2TMSb4LJmYkCp1Fyy25mquLHcdyq79NSFtkzEm+CyZmJAqqfDv/X7snklGVyeZ2CS8Md5jycSElH+YK6dVlwZbfS5jvMqSiQmpkooaundJJCUx/pjnZqZaz8QYr7JkYkJq5zG26w3kS4onKSHOij0a40GWTExIlbRyjQmAiJDZNcmGuYzxIEsmJqRKK2ro2YorufxsFbwx3mTJxISMqrP6PaeVPRNwLg+2nokx3mPJxITM3qo6ahsaj7opVnOZviSbMzHGgyyZmJA5uMNi63smGV1tmMsYL/JUMhGRZ0SkRERWBRx7UES2icgK9+u8SLbRHNSWBYt+Wb4kKmvqqalvCFWzjDEh4KlkAjwHnNPC8d+p6hj3650wt8kcQVNdrlYUefSztSbGeJOnkomqzgN2R7odpnV2trNnApZMjPEaTyWTo7hLRD51h8EyWjpBRG4VkaUisrS0tDTc7euUSspr8CXF40tOaPVjrD6XMd4UC8nkSWAQMAbYAfy2pZNU9SlVHaeq43JycsLZvk6rtKKmVfuYBMqyYS5jPMnzyURVd6pqg6o2Ak8D4yPdJuMoqahuVYHHQJn+Yo+VlkyM8RLPJxMR6R1w8xJg1ZHONeHllFJpW8+ke5dE4gT2VFkyMcZLWj+YHQVE5GVgKpAtIsXAA8BUERkDKFAEfCNiDTRNVJWS8po2Tb4DxMcJ6VafyxjP8VQyUdWrWjj817A3xBxTZU09B+oa2pxMwK3PZcNcxniK54e5THRqWv3ehrpcflbs0RjvsWRiQmJnuX+NSdvmTMBZa7Lb5kyM8RRLJiYkSttRl8svw3omxniOJRMTEu0ppeKX5UtiT1UtDY0a7GYZY0LEkokJiZKKapIT4uiW0vZrPDJ9SajCXhvqMsYzLJmYkPBv1ysibX5splufy9aaGOMdlkxMSDhrTNo+xAUHk4mtgjfGOyyZmJAoqahu1+Q7HEwmNglvjHdYMjEh0Z7V735Z/vpclkyM8QxLJiboDtQ2UFFT364ruQAyfIkAthe8MR5iycQEXXu26w2UnBBPanKC9UyM8RBLJiboDpZSaV/PBKykijFeY8nEBF3TgsV29kzAkokxXmPJxARdR4e5wK3PZcnEGM+wZGKCrqSihoQ4adrPvT2sZ2KMt1gyMUFXUl5DTloycXFtX/3u508mqlafyxgvsGRigq4jCxb9Mn1J1DY0UllTH6RWGWNCyZKJCTqnZ9L+K7nAVsEb4zWWTEzQlVRU07MdOywGykq1ZGKMl1gyMUFVW9/Inqq6dhd59PNP3lsyMcYbLJmYoCqtbP/e74GsPpcx3mLJxARVSXnH15gAZNowlzGeYsnEBFVTKZUODnP5kuJJSoizYo/GeIQlExNUB+tydaxnIiJkdk2yYS5jPMKSiQmqkvJqRJxyKB1lq+CN8Q5LJiaoSspryPIlkxDf8bdWVqr1TIzxCksmJqiCscbEL9OXZHMmxniEJRMTVCUV7d+ut7mMrjbMZYxXeCqZiMgzIlIiIqsCjmWKyH9EZIP7b0Yk29jZOcmkY1dy+WX5kqisqaemviEoz2eMCR1PJRPgOeCcZsfuB2ar6hBgtnvbREBDo7KrsqbDV3L52VoTY7zDU8lEVecBu5sdvhh43v3+eeArYW1UK1TXNbB2R3mkmxFyuypraNSOL1j0y7Jij8Z4hqeSyRH0VNUdAO6/PVo6SURuFZGlIrK0tLQ0rA18dmER5/1hPp99EdsJxb/GpKMVg/2sPpcx3hELyaRVVPUpVR2nquNycnLC+tpz15egCn+euzGsrxtuO/2lVII0zGWVg43xjlhIJjtFpDeA+29JhNtziKraepZt3kvXpHje+GQ7xXuqIt2kkDlYSiVYlwa7xR4rLZkYE+1iIZm8AVzvfn89MCuCbTnMkqI91DY08sCFwxHgL/M3RbpJIVNS7h/mCk4y6d4lkTiBPVWWTIyJdp5KJiLyMvARMFREikXk68AvgbNEZANwlns7aiz8vIyk+DguGp3LxWNyeWXJlpgdtimpqCajayLJCfFBeb74OCHd6nMZ4wmeSiaqepWq9lbVRFXNU9W/quouVT1DVYe4/za/2iui5m8o46T+GXRJiue2KflU1zXy/IdFkW5WSARzjYlfpi+J3TbMZUzU81Qy8ZqyyhrW7ihn0pBsAIb0TOPM43vy/EdFVNXWR7ZxIVBSEbw1Jn5W7NEYb7BkEkIfFu4CYOLg7KZjt0/NZ29VHa8s3hqpZoVMaXl10OZL/LJ8Sey2ORNjop4lkxBauKGMbikJjMzt3nTspP6ZnDwgg7/M30hdQ2MEWxdcjY0akmGuDOuZGOMJlkxCRFVZ8HkZpw3KJj5ODrnv9qmD2L6vmjdWbI9Q64JvT1Ut9Y0atMuC/bJ8SeypqqWhUYP6vMaY4LJkEiJFu6rYtvcAE4dkH3bftKE9GNozjT/PK6QxRv5IBmuHxeYyfUmowl4b6jImqlkyCZEFn5cBMGnw4clERLhtaj7rd1by38+iao1lu/mTSc9uwb+aC2ytiTHRzpJJiCzcUEZuehcGZHVt8f4LRvUhN70L0+cWhrlloVHiL6US5GEufzKxVfDGRDdLJiHQ0Kh8WFjGpMHZiEiL5yTGx3Hz5IEs3byHJUVRtTSmXQ6WUglNz8Qm4Y2JbpZMQmDVtn2UV9e3OF8S6MqT+5LRNZHpc7zfOymtqCEtOYEuScFZ/e6X5a/PZcnEmKhmySQE/PMlpw3KOup5XZMSuP60Acz+rIR1X1SEo2khU1JRTU6QJ98BMnyJALYXvDFRzpJJCCzYUMbxvbuRnXrsP67XnzqALonx/Hmet3snO8uDt/d7oOSEeFKTE6xnYkyUs2QSZAdqGyjYvIdJg4/eK/HL8CXx1fF9eWPFdrbtPRDi1oVOSUV10OdL/KykijHRz5JJkC0p2k1tQyOThrR+A66bJ+cD8Jf53tw8S1UpCVHPBCyZGOMFlkyCzF9y/uQBGa1+TG56Fy4a3YdXFm/15NxAeXU9NfWNQV9j4pflszL0xkQ7SyZBNn9DGWP7p9M1KaFNj/vGlEEcqGvg+Y+KQtKuUCqtCO52vc1l+JI8mWSN6UwsmQTRrsoa1uwob3HV+7EM7ZXGGcN68PyH3itPH+wdFpvLcoe5VMNfeiYSr2mMF1kyCaKWSs63xe1TB7Gnqo5Xl3irPH2oFiz6ZfqSqG1opLIm/En25ueXMuXRD5i1YlvM1FEzJhQsmQTRws/LSEtJYFReerseP25AJuP6Z/CX+Zs8VZ6+JMTDXJFaBb98yx5mf1ZC+YE67nllBRf+cQFz15dab8WYFlgyCRJVZf6GMk4blHVYyfm2uG3KILbtPcBbn3qnPP3O8hpSEuNIS27bPFFrRSqZTJ9bSPcuicz9/jR+d+Vo9h2o4/pnFnP104v4ZOvesLbFmGhnySRINrsl59szXxLoS8N6cFzPVKbP2eiZT8D+TbGOVIesoyKRTD4vqeTfa3bytVP70y0lkUtOzGP2d6bwwIXDWbezgoufWMgdLxawsbQybG0yJppZMgkSfwmV9s6X+MXFCd84fRDrdlbwwTpvlKcvKa8O2RoTiEx9rqfmFZIUH8f1pw1oOpacEM+NEwcy93tT+eYZQ5izrpSzfjePH7y2kp1u1WRjOitLJkGy8PMy+nRPYWC2r8PPddGYPvTpnsL0Od5YxFhaUROyNSYAmanh7Zl8sa+a15dv48qT+7ZYEictJZF7zzqOud+bxrUT+vGPpVuZ8ugH/Ppfn7HvQF1Y2mhMtLFkEgROyfldTBpy5JLzbeGUp89ncdFuCjZHf3n6koqakF0WDOBLiicpPi5sa02eWbiJRoVb3MoER5KTlsxDF49g9nemcPbwXvxpTiFTHv2Ap+YVUl3XEJa2GhMtQjNj2sms2raPfQfqOjzEFeir4/vyh/9u4Mk5G/nL9ZlBe96jeXreRtbuKG/TYxpVqaypD9mVXODsTJkZplXw+6rqePHjzZw/sjd9M1ve2Ky5/lk+/nDVidx6ej6/fm8dv3jnM55bWMStp+dzydg8undJDHGrjYk8SyZBcLDkfPCSSdekBK6Z0I8n5xTyxb5qenUP3TASwJZdVfz8nbVkpya1eU+S/Bwfp+S3rrBle4WrPtffFm1mf20Dt00Z1ObHjsjtzgs3jefDz8t49N/rePDNNfzyX59xwag+XD2hHyf2TQ/ZRQrGRJolkyBY+HkZw3qlBX2o54qT+vLEB4W8tryYO6YODupzNzdzWTEi8MZdk+iT3iWkr9UeWamh75lU1zXw7MJNTDkuh+F9urX7eU4bnM3rg7NZtW0fLy7awqwV25hRUMywXmlcM6EfF5+YS7cU662Y2GJzJh10oLaBpUV7OnxJcEsGZPsY1z+DmQXFIb1MuLFReW15MRMHZUdlIgGnZxLqOZN/FBRTVlnbrl5JS0bkdueRS0ey+Edn8vNLRhAfJ/zvrNVM+Pls7pvxKSu27vXM5d/GHIslkw5autlfcj74yQTg8pPyKCzdz4oQLpJbXLSbrbsPcPlJeSF7jY7K6BraYa76hkaenreRMX3TOSU/uHNUqckJXDOhP2/dPYlZd07kotF9eOOT7XzliYWc/4cF/O3jzREpFWNMMMVMMhGRIhFZKSIrRGRpuF53wYYyEuOF8QNDM0l+3qjeJCfEMXNZcUieH2BmQTGpyQl8+YReIXuNjsryJVFZU09NfWiuknp31Rds2V3FbVMGhWxeQ0QY3TedX10+ikU/OoOfXnwCjar8+J+rGP/z9/nBa5+ysnhfSF7bmFCLtTmTaapaFs4XXPB5GWP7ZbS55HxrdUtJ5JwRvXhjxXZ+fP5wUhLbNjl+LFW19byzcgcXjOrT5on3cApca9K7e3CH4lSV6XMLyc/xcfbwnkF97iPplpLIdacO4NpT+rN8615eWrSF15dv4+XFWxmZ252rJ/TjotF98IWoRI0xwRYzPZNI2L2/ltXb21dyvi0uG5tHeXU9s9cGf0X8v1Z9wf7aBi6L4iEucHomEJqFi/M3lLF6eznfOD2fuA7UVWsPEWFsvwx+c8VoFv3wTB666ARq6xv5wWsrmfCL2fzo9ZWs3m69FXNQXUMjG0sr2VsVXXv8xNLHHgX+LSIK/FlVnwr1C35Y6HSCQjVf4jdxcDa9uqUwo2Ar54/qHdTnnlFQTL/Mrm3aGTISMrqGLplMn1tIz27JfOXE3KA/d1t075LI9acN4Gun9mfZlj28uGgLMwqKeXHRFkb3Teea8f24YHTvkPWCTXTZvb+WjaWVbCzdT2FpJYWl+9lYVsmWXVXUNyr5OT7evWcyyQnRMaIQS+/Kiaq6XUR6AP8Rkc9UdZ7/ThG5FbgVoF+/fkF5QX/J+ZG53YPyfEcSHydcMjaXp+ZtpKSiOmj7hhTvqeKjjbv41hnHRf36h6wQlVT5ZOtePizcxQ/PGxY1v5Qiwkn9MzmpfyY/uWA4ry3bxkuLt/D9mZ/y07fWcMnYXK6e0I9hvdp/+bKJDrX1jWzZvd9JFKX7neRR5iSPvVUHS/MkxcfRP6srQ3qkcs4JvUhOiOd376/nyTmFfOvM4yIYwUExk0xUdbv7b4mIvA6MB+YF3P8U8BTAuHHjOnw9pr/k/Kn5WSTEh3608LKxeTw5p5BZy7dzy+lHL/PRWq8v24YqXDo2sp/IWyPTX+yxMrjJZPrcQtJSErhqfHA+YARbetckbpo0kBsnDmBJ0R5eWrSZV5Zs5YWPNjO2XzpXT+jP+SN7R/V8V2enquzaX9vUw/D3NjaW7WfL7ioaAjZdy0lLJj/bx7kjejMox8egnFTyc3zkZXQ9bGuLDSUV/OmDQi4a3Yf8nNRwh3WYmEgmIuID4lS1wv3+bODhUL7mlt1VFO85wK1B+sN+LIN7pDKmbzozCoq5efLADvckVJWZy4o5JT+z1WVDIql7l0TiBPYEcZx4Y2kl/1r9BXdMHURalC8iFHGuGBw/MJMH9tcyc1kxLy3awnf/8QkPv7maS8fmcc2EfgzpmRbppnZaNfUNbN5VxUZ3SKrQnzRKKymvPnjpd1JCHAOzfBzfO43zR/YmP8dHvps02rKY9ScXDGfuulJ+/M9VvHjzhIiPLsREMgF6Aq+7P8wE4CVV/VcoXzBYJefb4vKT8vjxP1exens5Izo4tFaweQ9Fu6q460tDgtS60IqPE9K7BncV/NPzN5IYH8cNpw0M2nOGQ4YviZsn5/P1SQP5eONuXlq8hRcXbea5D4s4eUAGV43vx3kjewf9yj/jfAgrrayhsMSZvwgcmtq6u4rAnZ17dksmPzuVC0f3aephDMpJpU96lw5toOfXo1sK3z9nKP87azX/XLGNS06M7EU0MZFMVHUjMDqcr+kvOZ8fhJLzrXXhqD48/NYaZhQUdziZzFxWTNekeM4dEb1rS5rL9CWxO0jDXCXl1cws2MYV4/JCWvE4lESEUwdlceqgLHZVDmdGQTEvL97CvX//hIfeXMNlY/O4ekI/BveI/BCI11TXNVC06+A8RqE/aZTupyJggWlyQhz5OamMyO3Oxe5wU36Oj4HZvrD0dq+e0J8Zy7bxs7fWMm1oD9LdC1UiISaSSbj5S86fdXzPsHYtu3dN5KzhPZm1Yhs/PO94khLaN1dTXdfAW5/s4NwRvT21jiGYxR7/unAT9Y2NYRumDLWs1GS+MWUQt0zO56ONu3hp0RZe+KiIZxZuYvzATK6Z0I9zRvSKmosMooGqUlJRQ2FJJYVl+w+5cmrb3gMEVrrp3T2F/Bwfl4zNJT/74LBUn+5dwn45eaD4OOEXl4zgoj8u5Ff/+rpDRmEAABnNSURBVIxHLh0VsbZ45y9JFFm9fR97q+pCfklwSy4fm8fbn+7gv5+VcE47exXvrf6Cipp6Ljsp+ifeA2X5kthQ0vFtcsur63jp4y2cN7I3/bPC17MMh7g4YeLgbCYOzqa0ooZ/FGzllcVbueeVFWR0TeTyk/K4any/qJiwDZcDtQ1sKnOGpZoPT+2vPVhRoUtiPPk5Pk7sl8FlY/OahqUGZvui+kPXCX26c9PEATw9fxOXjs3j5AHh2bKiuej9CUWxUJScb63JQ7LJSUtm5rLidieTGQXF5KZ34ZSBoS0bH2wZQeqZ/O3jzVTU1AetoGO0yklL5o6pg7nt9EEsLCzjpUVbeHZhEU/P38Sp+VlcPaEfXz6hV7t7uNFEVdmxr9q9Sqoy4Mqp/Wzbe+CQc3PTu5Cf4+OKcX2dye9sp5fRq1tKRHsZHfGtM4/j7U938KPXV/LW3ZMj8n9qyaQdQlVyvjUS4uO45MRcnlmwiV2VNWS1sK3s0Xyxr5qFn5dx17TBnvvFyfIlsaeqloZGbfcEZnVdA88sKGLykOwOzzt5RVycMHlIDpOH5FBSXs0/3LmVu19eTpYvicvH5XHVyf0YEMb5v/aqqq0/JFFsdIenNpXtpyqgl+FLiic/J5VxAzL4n+y+DOrhJI2B2b6YvIzal5zAQxeP4JYXlvKXBRtDvmVFSyyZtFF1XQNLivbwtVP6R6wNl43N46l5G5m1Yjs3TWrblUivLS+mUeHSsdFdPqUlmb4kVGFvVW2bk6jfa8u2UVZZw+1TxgS5dd7Qo1sKd04bzO1TBjFvQykvLdrCX+Zv4s9zNzJpcDZXT+jHWcN7khiGtVNH0tiobN934LBFfBtL97NjX3XTeSL+XkYq4wdmkp+TyiB3PqNnt+SIXyobbmcN78nZw3vyh9kbuHBUn7Bf8m/JpI2WFu2htr6RiRGYL/Eb2iuNkbndmVFQ3KZkoqrMLCjm5AEZnvgU2lxmQH2u9iSThkblqXmFjMrrzqmDvDXEF2xxccLUoT2YOrQHX+yr5u9Lt/LK4i3c8eIyslOT+Z9xztxKKP8gVdbUsylgIZ8zCb6fTWWVVNc1Np2XlpzQtJtnfraPQT2cYakBWT67/LmZBy86gbMem8v/zlrFszecHNaEasmkjeZ/XuqUnI/QJJffZWNzefDNNazZXt7qXQFXbN1LYel+bpnszSuYMjtY7PFfq76gaFcVT14zttN9aj2aXt1T+OYZQ7hz2mDmri/hpUVbmD63kCfnFjJpcDbXTOjPGcf3aFdvpaFR2b73QFPP4uDwVCU7y2uazosTyMvoyqAcH6cNymqayxiU4yMnrfP1MtqrT3oXvn3Wcfzs7bW8s/KLoNfyOxpLJm208PMyTuyXEfGrOy4ak8vP31nLzGXFDO8zvFWPmbmsmJTEOM4L4xssmDqSTPxl5gdm+zg7ivdtiaT4OOFLw3rypWE92b73AK8u2cqrS7Zy298K6JGWzP+M68tXx/clL+Pw3kp5dd3BYamASfCNZfuprT/Yy+iWkkB+TioTB2czKMdJFvk5qfTP6mqXLQfJDacN4PXl23jozdVMPi47bFtEWzJpA3/J+W9HQWG1TF8SXxrWg1krtnH/ucOO+amxuq6BN1Zs58sn9PLs/uNZ/vpc7Ugmc9aXsnLbPh65dGRQVh/HOv8n3Lu/NJgP1pXy8uItPDHnc56Y8zlTjsvhlPysptIhG8v2U1pxsJcRHyf0zejCoJxUJg/JdtZkuMNTWb4k62WEWEJ8HL+4ZCRf+dNCfvveOh66eER4XjcsrxIjlhTtRjX0Jedb6/KT+vLe6p3MW1/KGccffVOn2WtLKK+uj+qteY8lw+ckwbb0TErKq3l89gZeXbKV3PQuXBLhMvNekxAfx1nDe3LW8J5s23uAVxdv4ZUlW5mzrpT0ronkZ/uYclxOQLkQH/0yfTFxubGXje6bztdO6c8LH2/mkrF5jOmbHvLXtGTSBmcP78ns70yhf5QURpw6NIcsXxIzCoqPmUxmFGylV7eUiKyNCZbkhHhSkxNalUz2Hajjz3MLeWbhJhoalWsn9OOuLw2xCdsOyE3vwr1nD+WbZwyhsqY+oqU7zLF958tDeXfVF/zwtZW8cdfEkFc3t48PbSAiDMpJDUvJ+dZIjI/j4jG5zF5bwp6j/IEtKa9m3oYyLh2b6/khnmOVVKmua+DpeRuZ8ugH/GlOIV8+oRez753KQxeP8GwNrmiTEB9nicQDuqUk8sCFJ7BmRznPfVgU8teLjr+Kpt0uOymX2oZG3vx0+xHP+eeKbTQ0atRvzdsaR0omDY3K35du5Uu/mcPP31nLqLx03rp7Er//6on0y4qOnqQx4XbeyF5MHZrDY/9Zz/ZmlQCCzZKJx53QpzvH9+7GzILiFu931pZs48R+6QyKgXpMWb5Dy9CrKv9Zs5Nzfz+P78/4lJy0ZF66ZQIv3DS+06xwN+ZIRISfXjyCRlUefGN1SF/LkkkMuGxsLp8U72PDzorD7lu1rZx1Oyu4zIMr3luS4UtqGtJbUrSbK6Z/xC0vLKW+QfnTNWP5550TPT0vZEyw9c3syj1nHMe/1+zkP2t2hux1LJnEgK+cmEtCnDBj2eG9k5nLiklKiOPCUX0i0LLgc3omNdz8/BKumP4RW3ZX8YtLRvLet0/nvJG97bJTY1pw8+SBDO2ZxgOzVrE/YD+WYLJkEgOyU5OZOjSH15dto77h4AKx2vpGZq3YxlnDe9K9qzfXljSXnZpMXYOyaNNuvvflocz93jSuntAvorWkjIl2ifFx/OLSEWzfV83j768PyWvYpcEx4vKT8nh/bQkLPi9j6tAeAPz3sxL2VNV5em1Jc5eOzSUpIY6LRvchw2dXFBnTWif1z+Tes45jbL+MkDy/JZMYMW1YD9K7JjKjoLgpmcwoKCYnLZnJYdynPtSyUpO5/rQBkW6GMZ70zTOGhOy5bWwgRiQnxHPx6D78e81O9h2oo6yyhjnrSrj0xNyoWRdjjIld9lcmhlx2Uh619Y289el2Zq3YTn2MrC0xxkQ/G+aKISNzu3Ncz1RmFhRTXdfIqLzuHNczLdLNMsZ0AtYziSEiwmVj81i2ZS9rdpTHzNoSY0z0s2QSYy45MZc4gcR44aLRsbG2xBgT/WyYK8b06JbClSf3Izkhzi6dNcaEjSWTGPTIpSMj3QRjTCdjw1zGGGM6zJKJMcaYDrNkYowxpsNiJpmIyDkisk5EPheR+yPdHmOM6UxiIpmISDzwBHAuMBy4SkSGR7ZVxhjTecREMgHGA5+r6kZVrQVeAS6OcJuMMabTiJVkkgtsDbhd7B5rIiK3ishSEVlaWloa1sYZY0ysi5V1Ji1tr6eH3FB9CngKQERKRWQzkA2Uhb55EeGF2LzQxo6I5fhiOTaI7fg6Elv/I90RK8mkGOgbcDsP2H6kk1U1B0BElqrquBC3LSK8EJsX2tgRsRxfLMcGsR1fqGKLlWGuJcAQERkoIknAV4E3ItwmY4zpNGKiZ6Kq9SJyF/AeEA88o6qrI9wsY4zpNGIimQCo6jvAO2182FOhaEuU8EJsXmhjR8RyfLEcG8R2fCGJTVT12GcZY4wxRxErcybGGGMiyJKJMcaYDusUyUREWlqHYkxQ2PvLRBsRSQz3a8ZsMhHHt0UkT2NwYkhEhohISqTbcSxu3bSY+4Nr7y9vE5FRIpIa6XYEm/u+fBD4lv92uF47JpOJiHwN+AA4ESiPpT9kInKxiBQCDwN/EZHMSLepJSJyg4gsB+6JdFuCzd5f3iUi14jIp8BDwKvuurSYICLX4rwvvwZcCxDODzoxl0xEZCLwHPBdVf2aqpb7f6Be/6V3f7FvBq5W1auAEuBHInJcZFt2KBEZBtwBvAWcLiL5qqoi4vn3m72/vEtEzgW+AdyuqpcAg4AL3fs8+38nIvEi8nXgFuD7qpoPbBORE8LZDs//cgMEdldVdSHOivjj3fvuF5ELRSTVi8MRLXTFBWh0v38FuAw4L9KfsEQkzf+9qn6G8+nod8Aa4C73eGPLj45uzWKLtfdXWvNDROH7q738w6yuOap6uqouFJHuwEb3HPHo/108gKo2ALNUdYqqLhaR44EKWq5ZGDKeTyYi8n1gjoj8WkRudA/fATwvIiuAdOBu4FH3E7NnBMT2qIh8FdgDrASuF5EMYBywFOhFsyrJYW7n/cByEfmViNzgHl6nqruB14FBInK6e66n3nPNYvu6ezhW3l/+2H4tIle7/19R9/5qLxF5GPiJiOS4h2rc4z1xFjjvxUmWXvy/88fWA0BVy9zjoqprgQHAGPdYeH7nVNWTX0AWznDD390f2uXAIqC/e/+dwEnu9znAP4EvR7rd7YztCje2LCAfeAx4G3gROAGYAwyIUFu/BMwDBgLTgB3AqID7U3EmA18MOBYf6Z9xB2IbG/D+GufF99dRYjsOpyps1Ly/2hlbMvADYDPOh5mzWzinu/tvJk4dv/Mi3e5gxOb/3QK+CUwPZ9u8XE5lP/BvVX0JQJyS8ufgfILarKpP+E9U1VIR2Y3zxvGCI8WWr6pLgHtFpJeqfuHeX4wTW1EE2poILFfVTcAmEfk98Ahwvnv/fmAGcLyI/BTnl+HPQGEE2tpWLcX2C+Acj7+/4PDY/g/4rapeSHS9v9qjDme+7g84Q6zTRGSDGysAqrrP/Xe3iJQAGRFpadsdNTZ1hrzA6YXtc+eCRMMwxOypIYdAqloNvBlwqB7nU3xx4HkikikivwVG4Yx1R70jxDYa2Blwzhci0ldEnsBJoOvC28omXYEs/2WkqvpLoLeIXOHeVqAaGAncDpSqqhcSCbQcWw9/bODN95ereWy/AHJF5Er3drS8v9rM/cO5XlX3A6/ibEkxXkSS4eBku/t/9xucvxue+L9rRWz+OaLPgBvVEZa5Sk8kExGZGjDu2URVKwJuZgElqrol4HH5OJOIicAUVf085I1to/bG5noCp0ry+e6bK2RE5DoRGdn8uKq+jnNVzAUBh38N3Btw+xFgNdBPVR8NZTvbo72xichA4GWi+/3V1ti+FXD7j4Tp/dVeR4mvxv23CFgATAGGBTxuFM4wsv//bn1YGtwG7YktoGfyIfALEUkI25VqkR4DPNoXztDOPOBpoFvAcQHi9NAxwkm44/LAl4Gp7vdZkY4jBLGd7X7vC0M7RwOf4MwJjG7WzmT3+6+6sQxwb/fDSXRp7u2USP+8QxBbEpACZEY6jhDElure7hrpONoZX/Pfn27A/wFXA9cBF7jHcyIdR5Bjuxa4JFLtjro5E/8YH3Alztj611X1H4H3q/NTVLfnsRvnqozTgSQReRJnyOF+AFXdFeYQjigEsYXj0+J5wBPqbHvcxG1njdvOV4HhwI/FWah4IVCkbu9KnWG7aNSR2Grd02Mxtkr33Kowt7ktjhbfIb8/qlouIhtwEuUunMlpVLU0zG1urQ7HFglRNczl/2OqzhjfduAF4HP3vitEJA+nW4qI/AhYCEx0H34CMAH4TFUnqur8sAdwFF6JrYUu8TDAPxH7bRE5R0TS3dv3AYtxek6/BZ4FxgOzVfW2ULWxvSw2b8YG7YrvQ+BUcQzDGb57VFUHq7P3UdSIldiiZj8TcXZKPAOYj/OHdg/wdeBGnCstVuJs5rVTVW9zz39RVfe4j78AWKCqeyPR/qPxSmwB7ZwL/ENVt4nIIzhXXp2P8wbPwBlH/xlwKvCqv53uc8TrwXHbqGGxeTM26Hh87kUG8WHqybdJTMUWqfG1wC/gEpyrKabhfEp6Auea9z7AL4ET3fOycLpygeOIiZFufyzEdoR29sMZV/8vzicfcN7U/wUuDHhsPO4Hk2j8sti8GVsQ4kuIdPs7U2zRMsw1AXhSVT8AHsS5nv37qrodeFBVl0PT/MdruNeEu0NHdRFpcet5Jbbm7dwM/EBVX8H5dJQoIj3V+fT6Ic6VQP52Nqj7Do9SFps3Y4OOxVcfoTa3VkzFFtZk0nxsMOD2RpyrEVDVzThrLNJE5CINmLwVkf/FmT9Y654bNb8IXomtDe18A8gRkUnAoziLpX7gtvNynG65V/8PLLYoig1iO75Yji1QuHsmh2zYEvBDmQFUicjF7u0dOCUchgOIyGQR+QBneOgyVd1J9PFKbG1p53+B09ze0yM4C6G6Amf6e1RRxmLzZmwQ2/HFcmxNwnJpsIicirPQa7uI/BmnCGCDiCS43bU9OHVmbheRN1R1nzjVcru4T1EE3Kmqa8LR3rbwSmztbKcP8IFTdgKYHso2tpfF5s3YILbji+XYWhLynok4VS3/iFOlcxfOZkk3AQSM+3UB3sPJzE+JSB+cjYdq3fO2Rmki8URswWhntLLYvBkbxHZ8sRzbETWfkQ/2F3AW8LL7vQ9nBfdbwDD32M9wfqAn4hST+xnOMNCfiPLqsl6JzSvttNg6T2yxHl8sx3bEmEPwQ/wK8EOcej7glOfeAAxyb2cCDwC/whkLfMl/X8BzRGUZB6/E5pV2WmydJ7ZYjy+WY2vtV9CGuUQkR0T+iTNGuBt4VkQuV6dkwUycDYTAKQ8y2/3hpqjq1apaKAEbuGiUlXHwSmxeaWd7WGyAB2OD2I4vlmNrq2DOmQwCFqqzLeZ04DscrBz7MjBMRM5Up5zILqAnB3c+i9Po3tLVK7F5pZ3tYbF5MzaI7fhiObY26dDVXCLyNWALTp2fAmCTezweZ+/v1e6pK3FKwT8uIl/BKR8guJfMReMP1CuxeaWd7WGxAR6MDWI7vliOrSPanEzcBTe9cMb8GnFqyNwC3KOqO8Wt8SPOpvbdoemH9px7hcP9OIXMbtEoq6Plldi80s72sNi8GRvEdnyxHFvQtGWChYM19I8D/uZ+n4BTT/+1Zue8APyP+32vgOdICuakT7C+vBKbV9ppsXWe2GI9vliOLZhfreqZiEgC8DAQLyLv4GzI0gDONdMi8k2chTlTVHWu+7BKnL2lHwYuFZFzVLVYD+4DERW8EptX2tkeFps3Y4PYji+WYwuFY07Ai8gUnHHBDJz9N36KUzNmmoiMh6byAA/jFCvzjx3ehFMuoBswTVWLD3vyCPNKbF5pZ3tYbN6MDWI7vliOLWRa0cWbDFwXcPtPwO3ADUCBeywOZzzx70B/nCscHgfGRrrrFQuxeaWdFlvniS3W44vl2EL2M2vFD7UrkMzBMcFrgEfc71cAd7vfjwNeiXRAbXzDeCI2r7TTYus8scV6fLEcW6i+jjnMpapVqlqjB3dhOwvw7518I3C8iLyFc011AbS4DWVU8kpsXmlne1hs3owNYju+WI4tVFp9abA7Hqg4i27ecA9X4JQQGAFsUtVtEL319o/EK7F5pZ3tYbF5MzaI7fhiObZga8sK+EacxTZlwCg3K/8v0KiqC/w/UI/ySmxeaWd7WGzeFcvxxXJsQSVtSaYicgrO9pEfAs+q6l9D1bBw80psXmlne1hs3hXL8cVybMHU1mSSB1wHPKaqNSFrVQR4JTavtLM9LDbviuX4Yjm2YGpTMjHGGGNaEu494I0xxsQgSybGGGM6zJKJMcaYDrNkYowxpsMsmRhjjOkwSybGGGM6zJKJMS0QkQdF5LsdePxt4mzv2pbH9BGRGe19zVY8/w0i8sdjnDNVRE4LVRtM7OrQHvDGmJap6vR2PGY7cHkImtMWU3E2ePowwu0wHmM9E9NpiIhPRN4WkU9EZJWIXCkiRSKS7d4/TkTmBDxktIj8V0Q2iMgt7jlTRWSuiPxdRNaLyC9F5BoRWSwiK0VkkHteU89GRL4pImtE5FMRecU9NkVEVrhfy0UkTUQGiMgq9/4UEXnWfc7lIjLNPX6DiLwmIv9y2/XrY8R8o9vOucDEgOMXisgi97nfF5GeIjIAuA34ttuuySKSIyIzRWSJ+zXxCC9lOjnrmZjO5Bxgu6qeDyAi3YFfHeX8UcApgA9YLiJvu8dHA8cDu4GNwF9UdbyI3APcDXyr2fPcDwxU1RoRSXePfRe4U1UXikgqUN3sMXcCqOpIERkG/FtEjnPvGwOcCNQA60Tk/1R1a/PGi0hv4CHgJGAf8AGw3L17AXCKqqqI3Ax8X1W/IyLTgUpV/Y37HC8Bv1PVBSLSD3jPjd2YQ1jPxHQmK4EzReRXIjJZVfcd4/xZqnpAVctw/hCPd48vUdUdbp2mQuDfAc8/oIXn+RR4UUSuBerdYwuBx8TZRzxdVeubPWYS8P8AVPUzYDPgTyazVXWfqlYDa3B2+WvJBGCOqpaqswf5qwH35QHvichK4HvACUd4jjOBP4rICpwS7N1EJO0I55pOzJKJ6TRUdT3Op/SVwCMi8hOcP+7+34OU5g85wu3AYn+NAbcbabm3fz7whPvaBSKSoKq/BG4GugAfu72PQEfbaCnw9RuO8JrN29zc/wF/VNWRwDc4PHa/OOBUVR3jfuWqasVRXs90UpZMTKchIn2AKlX9G/AbYCxQhPNHHuCyZg+52J27yMKZmF7SjteMA/qq6gfA94F0IFVEBqnqSlX9FbAUaJ5M5uFsFYs7vNUPWNfGl18ETBWRLBFJBK4IuK874N+L4/qA4xVAYM/j38BdAfGMaWMbTCdhycR0JiOBxe6QzY+An+HMKfxeRObjfMoPtBh4G/gY+Kl7tVVbxQN/c4eTluPMP+wFvuVeBPAJcAB4t9nj/gTEu497FbihreXPVXUH8CDwEfA+sCzg7geBf7hxlwUcfxO4xD8BD3wTGOdePLAGZ4LemMNYCXpjjDEdZj0TY4wxHWaXBhsTA0RkEZDc7PB1qroyEu0xnY8NcxljjOkwG+YyxhjTYZZMjDHGdJglE2OMMR1mycQYY0yH/X8d+z6/nU3c2QAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "my_aggregated_df.plot(\"submission_date\", \"n_documents\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now save the results of our Pandas dataframe into our analysis environment. \n",
+    "\n",
+    "If the `pandas_gbq` package is installed, like in the Kaggle image, then Pandas can write directly into a table. See [the Pandas documentation](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_gbq.html) for reference.\n",
+    "\n",
+    "```python\n",
+    "my_aggregated_df.to_gbq(\"analysis.my_aggregated_table\")\n",
+    "```\n",
+    "\n",
+    "Instead, we'll use the [Google Cloud SDK to write into a table](https://cloud.google.com/bigquery/docs/datalab-migration#google-cloud-bigquery_7). Refer to the [`google-cloud-bigquery` api docs](https://googleapis.dev/python/bigquery/latest/index.html) for more details."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<google.cloud.bigquery.job.LoadJob at 0x7f8449ff3750>"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from google.cloud import bigquery\n",
+    "\n",
+    "client = bigquery.Client()\n",
+    "job = client.load_table_from_dataframe(my_aggregated_df, \"analysis.my_aggregated_table\")\n",
+    "job.result()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        tableId         Type    Labels   Time Partitioning   Clustered Fields  \n",
+      " --------------------- ------- -------- ------------------- ------------------ \n",
+      "  my_aggregated_table   TABLE                                                  \n",
+      "  my_table              TABLE                                                  \n"
+     ]
+    }
+   ],
+   "source": [
+    "! bq ls analysis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>submission_date</th>\n",
+       "      <th>n_documents</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2020-05-29 00:00:00+00:00</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2020-06-02 00:00:00+00:00</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2020-06-17 00:00:00+00:00</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2020-05-26 00:00:00+00:00</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2020-06-03 00:00:00+00:00</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>2020-06-09 00:00:00+00:00</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>2020-06-16 00:00:00+00:00</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>2020-05-28 00:00:00+00:00</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>2020-05-30 00:00:00+00:00</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>2020-05-31 00:00:00+00:00</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>2020-06-05 00:00:00+00:00</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>2020-06-04 00:00:00+00:00</td>\n",
+       "      <td>7</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>2020-05-27 00:00:00+00:00</td>\n",
+       "      <td>10</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>2020-06-01 00:00:00+00:00</td>\n",
+       "      <td>25</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             submission_date  n_documents\n",
+       "0  2020-05-29 00:00:00+00:00            1\n",
+       "1  2020-06-02 00:00:00+00:00            2\n",
+       "2  2020-06-17 00:00:00+00:00            2\n",
+       "3  2020-05-26 00:00:00+00:00            3\n",
+       "4  2020-06-03 00:00:00+00:00            3\n",
+       "5  2020-06-09 00:00:00+00:00            3\n",
+       "6  2020-06-16 00:00:00+00:00            5\n",
+       "7  2020-05-28 00:00:00+00:00            6\n",
+       "8  2020-05-30 00:00:00+00:00            6\n",
+       "9  2020-05-31 00:00:00+00:00            6\n",
+       "10 2020-06-05 00:00:00+00:00            6\n",
+       "11 2020-06-04 00:00:00+00:00            7\n",
+       "12 2020-05-27 00:00:00+00:00           10\n",
+       "13 2020-06-01 00:00:00+00:00           25"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%bigquery\n",
+    "SELECT * FROM analysis.my_aggregated_table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Appendix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cleanup\n",
+    "! bq rm -f analysis.my_table\n",
+    "! bq rm -f analysis.my_aggregated_table"
+   ]
+  }
+ ],
+ "metadata": {
+  "environment": {
+   "name": "common-cpu.m49",
+   "type": "gcloud",
+   "uri": "gcr.io/deeplearning-platform-release/base-cpu:m49"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1682428)

This adds a container for adding custom software to AI Platform Notebook instances, in particular those associated with Rally. This adds two template notebooks into an `/app` directory. I tried putting the notebooks into the `/home/jupyter` directory, but this gets overwritten on startup. I tested this with the following:

```bash
cd jobs/pioneer-debug
docker build -t pioneer-debug .  
docker tag pioneer-debug:latest gcr.io/amiyaguchi-dev/pioneer-debug
docker push gcr.io/amiyaguchi-dev/pioneer-debug 
```

Then I created a new AI platform notebook instance. It launched successfully. I opened a terminal and ran `cp -r /app/tutorials /home/jupyter` and was able to see the notebooks. 