### PR TITLE
Add etl-graph as a job via submodule

### DIFF
--- a/.circleci/config.template.yml
+++ b/.circleci/config.template.yml
@@ -31,6 +31,9 @@ jobs:
       - image: docker:stable-git
     steps:
       - checkout
+      - run:
+          name: Checkout git submodules
+          command: git submodule update --init --recursive
       - setup_remote_docker:
           version: 19.03.13
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,9 @@ jobs:
       - image: docker:stable-git
     steps:
       - checkout
+      - run:
+          name: Checkout git submodules
+          command: git submodule update --init --recursive
       - setup_remote_docker:
           version: 19.03.13
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,24 @@ jobs:
           name: Test Code
           command: docker run app:build pytest --flake8 --black
 
+  # As seen from the perpsective of https://github.com/mozilla/docker-etl
+  build-job-etl-graph:
+    docker:
+      - image: docker:stable-git
+    steps:
+      - checkout
+      - run:
+          name: Checkout git submodules
+          command: git submodule update --init --recursive
+      - compare-branch:
+          pattern: ^jobs/etl-graph/
+      - setup_remote_docker:
+          version: 19.03.13
+      - run:
+          name: Build Docker image
+          command: docker build -t app:build jobs/etl-graph/
+
+
   build-job-example_job:
     docker:
       - image: docker:stable-git
@@ -113,6 +131,20 @@ workflows:
           filters:
             branches:
               only: main
+
+  job-etl-graph:
+    jobs:
+      - build-job-etl-graph
+      - gcp-gcr/build-and-push-image:
+          context: data-eng-airflow-gcr
+          path: jobs/etl-graph/
+          image: etl-graph_docker_etl
+          requires:
+            - build-job-etl-graph
+          filters:
+            branches:
+              only: main
+
 
   job-example_job:
     jobs:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+Checklist for reviewer:
+
+- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
+  referenced, the pull request should include the bug number in the title)
+- [ ] Scan the PR and verify that no changes (particularly to
+  `.circleci/config.yml`) will cause environment variables (particularly
+  credentials) to be exposed in test logs
+- [ ] Ensure the container image will be using permissions granted to
+  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
+  responsibly. If this is an update to a submodule, take the time to review the
+  explicit diff of the submodule.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "jobs/etl-graph"]
+	path = jobs/etl-graph
+	url = https://github.com/mozilla/etl-graph.git

--- a/README.md
+++ b/README.md
@@ -18,7 +18,24 @@ e.g. the contents of a job named `my-job` would go into `jobs/my-job`
 All job directories should have a `Dockerfile`, a `ci_job.yaml`, 
 a `ci_workflow.yaml`, and a `README.md` in the root directory.          
 `ci_job.yaml` and `ci_workflow.yaml` contain the yaml structure that will be placed
-in the `- jobs:` and `- workflows:` sections of the CircleCI `config.yml` respectively
+in the `- jobs:` and `- workflows:` sections of the CircleCI `config.yml` respectively.
+
+#### Submodule Jobs
+
+Some jobs may take on the form of a [git
+submodule](https://github.blog/2016-02-01-working-with-submodules/). These
+directories must be initialized before contents are visible in the local
+filesystem. If you are contributing a submodule, ensure that it is checked out
+by adding the following line as a ci step.
+
+```bash
+git submodule update --init--recursive
+```
+
+The commit revision of the submodule must be updated on new changes;
+[Dependabot](https://dependabot.com/submodules/) will create a new PR with the
+latest updates for you. This must be merged to pushing new images to the shared
+GCR repository.
 
 ### Templates
 


### PR DESCRIPTION
The [etl-graph](https://github.com/mozilla/etl-graph) repo powers https://etl-graph.protosaur.dev. I thought it might be interesting to add it to docker-etl so I don't have to set up circle-ci with GCR and the appropriate contexts. I currently have an open PR to add docker support (https://github.com/mozilla/etl-graph/pull/8), and all I would need to do is add the two yaml fragments for scheduling here.

It does mean that that updating the container is a two step process of PR in the submodule, and then updating this repo with the new commit to build the container. [Dependabot has submodule support](https://dependabot.com/submodules/), so this could be less onerous to keep up to date. 

@BenWu do you have particular thoughts about whether this workflow is appropriate in this context. I have another job that I think would fit this submodule pattern (https://github.com/mozilla/mozaggregator2bq) and would save a bit of time with the circleci config. 