### PR TITLE
Add dependabot support for git submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      # check 2 hours before Airflow deploys
+      time: "22:00"


### PR DESCRIPTION
It turns out that dependabot doesn't have live updates for submodules, which puts a hamper on efforts of using submodules. I still want to try this out though, so I've set updates to occur daily 2 hours before most of our airflow jobs start.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly. If this is an update to a submodule, take the time to review the
  explicit diff of the submodule.