### PR TITLE
Bump etl-graph submodule for workspace location mishap

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ workflows:
       - build-job-etl-graph
       - gcp-gcr/build-and-push-image:
           attach-workspace: true
-          workspace-root: jobs/etl-graph
+          workspace-root: jobs
           context: data-eng-airflow-gcr
           path: jobs/etl-graph/
           image: etl-graph_docker_etl


### PR DESCRIPTION
https://github.com/mozilla/etl-graph/pull/11, this needs to be updated for the final location after the PR has been merged. 

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly. If this is an update to a submodule, take the time to review the
  explicit diff of the submodule.