### PR TITLE
Add docker-context to workflow defintions to avoid top-level requirements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,7 @@ workflows:
       - build-job-etl-graph
       - gcp-gcr/build-and-push-image:
           context: data-eng-airflow-gcr
+          docker-context: jobs/etl-graph/
           path: jobs/etl-graph/
           image: etl-graph_docker_etl
           requires:

--- a/jobs/etl-graph/ci_workflow.yaml
+++ b/jobs/etl-graph/ci_workflow.yaml
@@ -3,6 +3,7 @@ job-etl-graph:
     - build-job-etl-graph
     - gcp-gcr/build-and-push-image:
         context: data-eng-airflow-gcr
+        docker-context: jobs/etl-graph/
         path: jobs/etl-graph/
         image: etl-graph_docker_etl
         requires:

--- a/templates/default/ci_workflow.template.yaml
+++ b/templates/default/ci_workflow.template.yaml
@@ -3,6 +3,7 @@ job-{{ job_name }}:
     - build-job-{{ job_name }}
     - gcp-gcr/build-and-push-image:
         context: data-eng-airflow-gcr
+        docker-context: jobs/{{ job_name }}/
         path: jobs/{{ job_name }}/
         image: {{ job_name }}_docker_etl
         requires:

--- a/templates/python/ci_workflow.template.yaml
+++ b/templates/python/ci_workflow.template.yaml
@@ -3,6 +3,7 @@ job-{{ job_name }}:
     - build-job-{{ job_name }}
     - gcp-gcr/build-and-push-image:
         context: data-eng-airflow-gcr
+        docker-context: jobs/{{ job_name }}/
         path: jobs/{{ job_name }}/
         image: {{ job_name }}_docker_etl
         requires:


### PR DESCRIPTION
This adds the docker-context to the workflow definition so it doesn't install the requirements.txt from the top-level. See https://github.com/mozilla/etl-graph/pull/12 for relevant errors.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
