### PR TITLE
fixed flake8 errors for desktop-mobile-mau-2020

### DIFF
--- a/jobs/desktop-mobile-mau-2020/desktop_mau/desktop_mau_dau.py
+++ b/jobs/desktop-mobile-mau-2020/desktop_mau/desktop_mau_dau.py
@@ -27,10 +27,10 @@ IMG_DIR = STATIC_DIR / "img"
 DESKTOP_QUERY = (ROOT_DIR / "mau_dau.sql").read_text()
 
 DESKTOP_USER_STATE_QUERY = """
-SELECT 
+SELECT
     *
-FROM 
-    `moz-fx-data-derived-datasets.analysis.xluo_kpi_plot_country_new_or_rescurrected_dau` 
+FROM
+    `moz-fx-data-derived-datasets.analysis.xluo_kpi_plot_country_new_or_rescurrected_dau`
 """
 
 
@@ -454,7 +454,8 @@ def plot_dau_mau_ratio(desktop_data):
         fontdict={"fontsize": 18, "color": "black"},
     )
 
-    # axs[1].plot.area([ind_dat["country_x"].isin(country_list)]["date", "country_x", "pcnt"], subplots=True)
+    # axs[1].plot.area([ind_dat["country_x"]\
+    # .isin(country_list)]["date", "country_x", "pcnt"], subplots=True)
     dat2 = ind_dat[ind_dat["country_x"].isin(country_list)][
         ["date", "country_x", "pcnt_MAU"]
     ].pivot(index="date", columns="country_x", values="pcnt_MAU")

--- a/jobs/desktop-mobile-mau-2020/mobile_mau/mobile_mau.py
+++ b/jobs/desktop-mobile-mau-2020/mobile_mau/mobile_mau.py
@@ -57,7 +57,7 @@ def create_table(template, platform, actual, forecast):
         - 1
     )
 
-    data_end_date = actual["date"].max().date()
+    # data_end_date = actual["date"].max().date()
 
     return template.render(
         platform=platform,
@@ -84,7 +84,8 @@ def create_table(template, platform, actual, forecast):
 
 def create_plot(platform, y_min, y_max, actuals, forecast, plot_start_date, slice_name):
     """
-    Display a plot given a platform (each mobile product), data for actuals and forecast, and slice (Global or Tier 1).
+    Display a plot given a platform (each mobile product),
+    data for actuals and forecast, and slice (Global or Tier 1).
     """
     main_metric_color = "#CA3524"
     main_metric_color_ci = "#DDDDDD"
@@ -185,7 +186,9 @@ def create_plot(platform, y_min, y_max, actuals, forecast, plot_start_date, slic
         # autosize=force_width is None,
         # width=force_width,
         # height=force_height,
-        title='<b>{} {} MAU</b> <span style="font-size: medium;">at end of day {}</span>'.format(
+        title="""
+        <b>{} {} MAU</b> <span style="font-size: medium;">at end of day {}</span>
+        """.format(
             slice_name,
             platform,
             data_end_date,

--- a/jobs/desktop-mobile-mau-2020/mobile_mau/mobile_mau.py
+++ b/jobs/desktop-mobile-mau-2020/mobile_mau/mobile_mau.py
@@ -186,13 +186,13 @@ def create_plot(platform, y_min, y_max, actuals, forecast, plot_start_date, slic
         # autosize=force_width is None,
         # width=force_width,
         # height=force_height,
-        title="""
-        <b>{} {} MAU</b> <span style="font-size: medium;">at end of day {}</span>
+        title="""\
+        <b>{} {} MAU</b> <span style="font-size: medium;">at end of day {}</span>\
         """.format(
             slice_name,
             platform,
             data_end_date,
-        ),
+        ).strip(),
         titlefont={
             "size": 24,
         },

--- a/jobs/desktop-mobile-mau-2020/requirements.txt
+++ b/jobs/desktop-mobile-mau-2020/requirements.txt
@@ -3,6 +3,7 @@ google-cloud-bigquery==1.27.2
 google-cloud-bigquery-storage==1.0.0
 google-cloud-storage==1.31.0
 Jinja2==2.11.3
+flake8==3.8.4
 matplotlib==3.3.2
 numpy==1.19.2
 pandas==1.1.2


### PR DESCRIPTION
Seems to be a known issue with flake8 and pytest flake8 plugin whereby the plugin doesn't play nicely with flake8 version > 5.

Seems like someone tried to address the issue and their PR has been merged. However, the change does not seem to be released yet. My guess is the next release of pytest-flake8 will include it:
https://github.com/tholo/pytest-flake8/pull/88

All jobs now complete successfully in CI:
![image](https://user-images.githubusercontent.com/42538694/183401262-7f5fc84a-dd14-4bff-96e0-7812252062c3.png)
