### PR TITLE
Revert "Fix import location"

### DIFF
--- a/jobs/search-term-data-validation/Dockerfile
+++ b/jobs/search-term-data-validation/Dockerfile
@@ -1,10 +1,12 @@
 FROM python:3
 MAINTAINER Chelsea Troy <ctroy@mozilla.com>
 
-WORKDIR /usr/app/src
+WORKDIR /usr/app/
 
 RUN pip install --upgrade pip
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 
 COPY . .
+
+WORKDIR /usr/app/src/

--- a/jobs/search-term-data-validation/tests/test_data_validation.py
+++ b/jobs/search-term-data-validation/tests/test_data_validation.py
@@ -1,5 +1,5 @@
 import pytest
-from data_validation import range_check, mean_check
+from src.data_validation import range_check, mean_check
 import pandas as pd
 import numpy as np
 

--- a/jobs/search-term-data-validation/tests/test_data_validation.py
+++ b/jobs/search-term-data-validation/tests/test_data_validation.py
@@ -1,5 +1,5 @@
 import pytest
-from src.data_validation import range_check, mean_check
+from data_validation import range_check, mean_check
 import pandas as pd
 import numpy as np
 


### PR DESCRIPTION
Reverts mozilla/docker-etl#79

This made the tests pass on CI, but I think it might have broken the actual job—unclear why, though. 