### PR TITLE
Adjust Dockerfile to end up in the right place while installing imports and then running data val job

### DIFF
--- a/jobs/search-term-data-validation/Dockerfile
+++ b/jobs/search-term-data-validation/Dockerfile
@@ -2,9 +2,12 @@ FROM python:3
 MAINTAINER Chelsea Troy <ctroy@mozilla.com>
 
 WORKDIR /usr/app/src
+WORKDIR /usr/app/
 
 RUN pip install --upgrade pip
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 
 COPY . .
+
+WORKDIR /usr/app/src/

--- a/jobs/search-term-data-validation/Dockerfile
+++ b/jobs/search-term-data-validation/Dockerfile
@@ -1,7 +1,6 @@
 FROM python:3
 MAINTAINER Chelsea Troy <ctroy@mozilla.com>
 
-WORKDIR /usr/app/src
 WORKDIR /usr/app/
 
 RUN pip install --upgrade pip
@@ -9,5 +8,3 @@ COPY requirements.txt .
 RUN pip install -r requirements.txt
 
 COPY . .
-
-WORKDIR /usr/app/src/


### PR DESCRIPTION
Why we're CDing twice:

1. We need to be in app/ to install the dependencies
2. Then we need to be in app/src/ to run the script itself

