### PR TITLE
Retrieve job metadata metrics in ascending order to support calculating moving average windows

### DIFF
--- a/jobs/search-term-data-validation/Dockerfile
+++ b/jobs/search-term-data-validation/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.10
 MAINTAINER Chelsea Troy <ctroy@mozilla.com>
 
 WORKDIR /usr/app/

--- a/jobs/search-term-data-validation/src/data_validation.py
+++ b/jobs/search-term-data-validation/src/data_validation.py
@@ -60,7 +60,7 @@ def calculate_data_validation_metrics(metadata_source, languages_source):
     ) AS languages
     ON metadata.started_at = languages.job_start_time
     WHERE status = 'SUCCESS'
-    ORDER BY finished_at DESC;
+    ORDER BY finished_at ASC;
     """
     client = bigquery.Client()
     query_job = client.query(SUCCESSFUL_SANITIZATION_JOB_RUN_METADATA)
@@ -142,7 +142,7 @@ def retrieve_data_validation_metrics(metrics_source):
     SELECT
         *
         FROM `{metrics_source_no_injection}` AS metadata
-    ORDER BY finished_at DESC;
+    ORDER BY finished_at ASC;
     """
     client = bigquery.Client()
     query_job = client.query(DATA_VALIDATION_METRICS_QUERY)


### PR DESCRIPTION
These need to be retrieved in _ascending_ order so that moving average windows are calculated on the five days in the _past_, not the ones in the _future!_ 

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
