### PR TITLE
Change ownership of the quicksuggest2bq job

### DIFF
--- a/jobs/quicksuggest2bq/Dockerfile
+++ b/jobs/quicksuggest2bq/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.8
-MAINTAINER Alessio Placitelli <aplacitelli@mozilla.com>
+MAINTAINER Chelsea Troy <ctroy@mozilla.com>
 
 # https://github.com/mozilla-services/Dockerflow/blob/master/docs/building-container.md
 ARG USER_ID="10001"

--- a/jobs/quicksuggest2bq/Dockerfile
+++ b/jobs/quicksuggest2bq/Dockerfile
@@ -1,5 +1,4 @@
 FROM python:3.8
-MAINTAINER Chelsea Troy <ctroy@mozilla.com>
 
 # https://github.com/mozilla-services/Dockerflow/blob/master/docs/building-container.md
 ARG USER_ID="10001"


### PR DESCRIPTION
I'm no longer involved in this work, so this might benefit from an owner who is more involved with it!

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
