### PR TITLE
make forecast deterministic

### DIFF
--- a/jobs/kpi-forecasting/docker-compose.yml
+++ b/jobs/kpi-forecasting/docker-compose.yml
@@ -9,6 +9,6 @@ services:
       # Mount the local gcloud sdk configuration when developing. Note that this
       # will modify the contents on the host.
       - ${CLOUDSDK_CONFIG}/:/tmp/.config/gcloud
-    environment:s
+    environment:
       - CLOUDSDK_CONFIG=/tmp/.config/gcloud
       - CLOUDSDK_CORE_PROJECT

--- a/jobs/kpi-forecasting/kpi-forecasting/Utils/FitForecast.py
+++ b/jobs/kpi-forecasting/kpi-forecasting/Utils/FitForecast.py
@@ -1,16 +1,18 @@
-from datetime import datetime
+import holidays
+import numpy as np
+import pandas as pd
+import prophet
 import typing
 
-import pandas as pd
-
-import prophet
-
-import holidays
+from datetime import datetime
 
 
 def run_forecast(
     dataset: pd.DataFrame, config: dict
 ) -> typing.Tuple[pd.DataFrame, pd.DataFrame]:
+    # Set random seed to ensure forecast is deterministic
+    np.random.seed(42)
+
     target = config["target"]
 
     fit_parameters = config[


### PR DESCRIPTION
Following [this comment](https://github.com/facebook/prophet/issues/1124#issuecomment-812904897), this PR sets a `np.random.seed` to ensure that Prophet forecasts are deterministic (and therefore repeatable). I checked that the forecasts are indeed repeatable by running locally after adding the following line to `kpi_forecasting.py` before results were written to bigquery:

```python
print(predictions.iloc[:, 1:].sum().sum() + confidences.iloc[:, 4:].sum().sum())
```

This sums all of the numeric columns in the `predictions` and `confidences` dataframes to provide a quick check that dataframes are equal across runs. This is not the most exhaustive check that could exist, but imo it's a sufficient demonstration for our use case.

```
# without setting np.random.seed
> 750505443639.0608
> 750445662883.6375
> 750454470768.1648

# after setting np.random.seed
> 750462584055.1995
> 750462584055.1995
> 750462584055.1995
```

Additional Changes:
- Reorder imports

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
