### PR TITLE
cast ds as timestamp

### DIFF
--- a/jobs/kpi-forecasting/kpi-forecasting/Utils/DBWriter.py
+++ b/jobs/kpi-forecasting/kpi-forecasting/Utils/DBWriter.py
@@ -23,6 +23,7 @@ def write_predictions_to_bigquery(
     predictions["target"] = config["target"]
     predictions["forecast_date"] = today
     predictions["forecast_parameters"] = str(forecast_parameters)
+    predictions["ds"] = pd.to_datetime(predictions["ds"])
 
     output_table = config["output_table"]
 


### PR DESCRIPTION
The Airflow task [did not succeed](https://workflow.telemetry.mozilla.org/log?dag_id=kpi_forecasting&task_id=kpi_forecasting_desktop_non_cumulative&execution_date=2023-05-06T04%3A00%3A00%2B00%3A00) after recent PRs. This appears to be due to the type of the `predictions["ds"]`; the current column type is `DATETIME`, but the BQ schema uses `TIMESTAMP`. From the Airflow logs:
```
Provided Schema does not match Table moz-fx-data-shared-prod:telemetry_derived.kpi_automated_forecast_v1. Field ds has changed type from TIMESTAMP to DATETIME
```

This type change was not intentionally made in the previous PRs, but is likely a result of updating the `prophet` package. This PR forces `predictions["ds"]` to be a `TIMESTAMP` at the time of db write.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
