### PR TITLE
Update mozaggregator-backfill bucket

### DIFF
--- a/jobs/mozaggregator2bq/bin/backfill
+++ b/jobs/mozaggregator2bq/bin/backfill
@@ -22,7 +22,7 @@ function run_day {
     
     local input="$DATA_DIR/$aggregate_type/$ds_nodash"
     local intermediate="$DATA_DIR/parquet/$aggregate_type/$ds_nodash"
-    local output=gs://$PROJECT/$DATA_DIR/$aggregate_type/$ds_nodash
+    local output=gs://moz-fx-data-prod-external-data/mozaggregator-backfill/$aggregate_type/$ds_nodash
     
     # check if this has already been done
     if ! gsutil stat "$output/_SUCCESS"; then


### PR DESCRIPTION
Updates mozaggregator-backfill to temporarily (until we disable it again) use a bucket that exist and prevent airflow from failing.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
