### PR TITLE
Update default forecasting horizon to 18 months

### DIFF
--- a/jobs/kpi-forecasting/kpi-forecasting/models/base_forecast.py
+++ b/jobs/kpi-forecasting/kpi-forecasting/models/base_forecast.py
@@ -99,8 +99,8 @@ class BaseForecast:
 
     @property
     def _default_end_date(self) -> str:
-        """64 weeks (16 months) ahead of the current UTC date."""
-        return (datetime.utcnow() + timedelta(weeks=64)).date()
+        """78 weeks (18 months) ahead of the current UTC date."""
+        return (datetime.utcnow() + timedelta(weeks=78)).date()
 
     def _set_seed(self) -> None:
         """Set random seed to ensure that fits and predictions are reproducible."""


### PR DESCRIPTION
This change will help the revenue team get the forecast data for the horizon that they need.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
