### PR TITLE
Debug changes introduced in PR 156

### DIFF
--- a/jobs/kpi-forecasting/Dockerfile
+++ b/jobs/kpi-forecasting/Dockerfile
@@ -18,9 +18,9 @@ RUN apt-get -y update && apt-get -y install \
 RUN pip install --upgrade pip --no-cache-dir
 
 COPY requirements.txt requirements.txt
-RUN pip install -r requirements.txt --no-cache-dir
 
 COPY . .
+RUN pip install -e . -r requirements.txt --no-cache-dir
 
 # Drop root and change ownership of the application folder to the user
 RUN chown -R ${USER_ID}:${GROUP_ID} ${HOME}

--- a/jobs/kpi-forecasting/README.md
+++ b/jobs/kpi-forecasting/README.md
@@ -34,7 +34,7 @@ A metric can be forecasted by using a command line argument that passes the rele
 For example, the following command forecasts Desktop DAU numbers:
 
 ```sh
-python ~/kpi_forecasting/kpi_forecasting.py -c ~/kpi_forecasting/configs/dau_desktop.yaml
+python ~/kpi_forecasting.py -c ~/kpi_forecasting/configs/dau_desktop.yaml
 ```
 
 ### Local Python

--- a/jobs/kpi-forecasting/kpi_forecasting.py
+++ b/jobs/kpi-forecasting/kpi_forecasting.py
@@ -1,6 +1,6 @@
-from inputs import CLI, YAML
-from models.prophet_forecast import ProphetForecast
-from metric_hub import MetricHub
+from kpi_forecasting.inputs import CLI, YAML
+from kpi_forecasting.models.prophet_forecast import ProphetForecast
+from kpi_forecasting.metric_hub import MetricHub
 
 
 # A dictionary of available models in the `models` directory.

--- a/jobs/kpi-forecasting/kpi_forecasting/metric_hub.py
+++ b/jobs/kpi-forecasting/kpi_forecasting/metric_hub.py
@@ -69,9 +69,9 @@ class MetricHub:
         """Fetch the relevant metric values from Big Query."""
         print(
             f"\nQuerying for '{self.app_name}.{self.slug}' aliased as '{self.alias}':"
-            f"\n{self.query}"
+            f"\n{self.query()}"
         )
-        df = bigquery.Client(project=self.project).query(self.query).to_dataframe()
+        df = bigquery.Client(project=self.project).query(self.query()).to_dataframe()
 
         # ensure submission_date has type 'date'
         df[self.submission_date_column] = pd.to_datetime(


### PR DESCRIPTION
Debugs some changes in https://github.com/mozilla/docker-etl/pull/156 that were introduced to make `kpi-forecasting` pip installable:
- Moves the `kpi_forecasting.py` script out of the module. Python doesn't like invoking scripts that are part of a module.
- Modifies the Dockerfile to install `kpi_forecasting` as a package.
- Modifies `MetricHub.query` to be invoked like a method instead of accessed like an attribute. The change from attribute to method was made in the previous PR, but the invocation changes wasn't pushed.
- Update readme

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
