### PR TITLE
Fixes #163 - Add a job for ML classification of broken site reports using bugbug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,22 @@ jobs:
           name: Build Docker image
           command: docker build -t app:build jobs/bq2sftp/
 
+  build-job-broken-site-report-ml:
+    docker:
+      - image: << pipeline.parameters.git-image >>
+    steps:
+      - checkout
+      - compare-branch:
+          pattern: ^jobs/broken-site-report-ml/
+      - setup_remote_docker:
+          version: << pipeline.parameters.docker-version >>
+      - run:
+          name: Build Docker image
+          command: docker build -t app:build jobs/broken-site-report-ml/
+      - run:
+          name: Test Code
+          command: docker run app:build pytest --flake8 --black
+
   build-job-client-regeneration:
     docker:
       - image: << pipeline.parameters.git-image >>
@@ -331,6 +347,20 @@ workflows:
             branches:
               only: main
 
+
+  job-broken-site-report-ml:
+    jobs:
+      - build-job-broken-site-report-ml
+      - gcp-gcr/build-and-push-image:
+          context: data-eng-airflow-gcr
+          docker-context: jobs/broken-site-report-ml/
+          path: jobs/broken-site-report-ml/
+          image: broken-site-report-ml_docker_etl
+          requires:
+            - build-job-broken-site-report-ml
+          filters:
+            branches:
+              only: main
 
   job-client-regeneration:
     jobs:

--- a/jobs/broken-site-report-ml/.dockerignore
+++ b/jobs/broken-site-report-ml/.dockerignore
@@ -1,0 +1,7 @@
+.ci_job.yaml
+.ci_workflow.yaml
+.DS_Store
+*.pyc
+.pytest_cache/
+__pycache__/
+venv/

--- a/jobs/broken-site-report-ml/.flake8
+++ b/jobs/broken-site-report-ml/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 88

--- a/jobs/broken-site-report-ml/.gitignore
+++ b/jobs/broken-site-report-ml/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+*.pyc
+__pycache__/
+venv/

--- a/jobs/broken-site-report-ml/Dockerfile
+++ b/jobs/broken-site-report-ml/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.8
+MAINTAINER REPLACE ME <replaceme@mozilla.com>
+
+# https://github.com/mozilla-services/Dockerflow/blob/master/docs/building-container.md
+ARG USER_ID="10001"
+ARG GROUP_ID="app"
+ARG HOME="/app"
+
+ENV HOME=${HOME}
+RUN groupadd --gid ${USER_ID} ${GROUP_ID} && \
+    useradd --create-home --uid ${USER_ID} --gid ${GROUP_ID} --home-dir ${HOME} ${GROUP_ID}
+
+WORKDIR ${HOME}
+
+RUN pip install --upgrade pip
+
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+
+COPY . .
+
+RUN pip install .
+
+# Drop root and change ownership of the application folder to the user
+RUN chown -R ${USER_ID}:${GROUP_ID} ${HOME}
+USER ${USER_ID}

--- a/jobs/broken-site-report-ml/README.md
+++ b/jobs/broken-site-report-ml/README.md
@@ -1,0 +1,45 @@
+# Python Template Job
+
+This is an example of a dockerized Python job.
+
+## Usage
+
+This script is intended to be run in a docker container.
+Build the docker image with:
+
+```sh
+docker build -t python-template-job .
+```
+
+To run locally, install dependencies with:
+
+```sh
+pip install -r requirements.txt
+```
+
+Run the script with 
+
+```sh   
+python3 -m python_template_job.main
+```
+
+## Development
+
+Run tests with:
+
+```sh
+pytest
+```
+
+`flake8` and `black` are included for code linting and formatting:
+
+```sh
+pytest --black --flake8
+```
+
+or
+
+```sh
+flake8 python_template_job/ tests/
+black --diff python_template_job/ tests/
+```

--- a/jobs/broken-site-report-ml/broken_site_report_ml/main.py
+++ b/jobs/broken-site-report-ml/broken_site_report_ml/main.py
@@ -1,0 +1,202 @@
+import click
+import datetime
+import logging
+import requests
+import time
+
+from google.cloud import bigquery
+
+BUGBUG_HTTP_SERVER = "https://bugbug.herokuapp.com"
+CLASSIFICATION_LABELS = {0: "valid", 1: "invalid"}
+
+
+def classification_http_request(url, reports):
+    reports_list = list(reports.values())
+    response = requests.post(
+        url, headers={"X-Api-Key": "docker-etl"}, json={"reports": reports_list}
+    )
+
+    response.raise_for_status()
+
+    return response.json()
+
+
+def get_reports_classification(model, reports, retry_count=21, retry_sleep=10):
+    """Get the classification for a list of reports.
+
+    Args:
+        model: The model to use for the classification.
+        reports: The dict containing reports to classify with uuid used as keys.
+        retry_count: The number of times to retry the request.
+        retry_sleep: The number of seconds to sleep between retries.
+
+    Returns:
+        A dictionary with the uuids as keys and classification results as values.
+    """
+    if len(reports) == 0:
+        return {}
+
+    url = f"{BUGBUG_HTTP_SERVER}/{model}/predict/broken_site_report/batch"
+
+    json_response = {}
+
+    for _ in range(retry_count):
+        response = classification_http_request(url, reports)
+
+        # Check which reports are ready
+        for uuid, data in response["reports"].items():
+            if not data.get("ready", True):
+                continue
+
+            # The report is ready, add it to the json_response and pop it
+            # up from the current batch
+            reports.pop(uuid, None)
+            json_response[uuid] = data
+
+        if len(reports) == 0:
+            break
+        else:
+            time.sleep(retry_sleep)
+
+    else:
+        total_sleep = retry_count * retry_sleep
+        msg = f"Couldn't get {len(reports)} report classifications in {total_sleep} seconds, aborting"  # noqa
+        logging.error(msg)
+        raise Exception(msg)
+
+    return json_response
+
+
+def add_classification_results(client, bq_dataset_id, results):
+    res = []
+    for uuid, result in results.items():
+        bq_result = {
+            "report_uuid": uuid,
+            "label": CLASSIFICATION_LABELS[result["class"]],
+            "created_at": datetime.datetime.utcnow().isoformat(),
+            "probability": result["prob"][result["class"]],
+            "is_ml": True,
+        }
+        res.append(bq_result)
+
+    job_config = bigquery.LoadJobConfig(
+        source_format=bigquery.SourceFormat.NEWLINE_DELIMITED_JSON,
+        schema=[
+            bigquery.SchemaField("report_uuid", "STRING", mode="REQUIRED"),
+            bigquery.SchemaField("label", "STRING", mode="REQUIRED"),
+            bigquery.SchemaField("created_at", "DATETIME", mode="REQUIRED"),
+            bigquery.SchemaField("probability", "FLOAT"),
+            bigquery.SchemaField("is_ml", "BOOLEAN", mode="REQUIRED"),
+        ],
+        write_disposition="WRITE_APPEND",
+    )
+
+    labels_table = f"{bq_dataset_id}.labels"
+
+    job = client.load_table_from_json(
+        res,
+        labels_table,
+        job_config=job_config,
+    )
+
+    logging.info("Writing to `labels` table")
+
+    try:
+        job.result()
+    except Exception as e:
+        print(f"ERROR: {e}")
+        if job.errors:
+            for error in job.errors:
+                logging.error(error)
+
+    table = client.get_table(labels_table)
+    logging.info(f"Loaded {len(res)} rows into {table}")
+
+
+def record_classification_run(client, bq_dataset_id, is_ok, count):
+    rows_to_insert = [
+        {
+            "run_at": datetime.datetime.utcnow().isoformat(),
+            "is_ok": is_ok,
+            "report_count": count,
+        },
+    ]
+    bugbug_runs_table = f"{bq_dataset_id}.bugbug_classification_runs"
+    errors = client.insert_rows_json(bugbug_runs_table, rows_to_insert)
+    if errors:
+        logging.error(errors)
+    else:
+        logging.info("Last classification run recorded")
+
+
+def get_last_classification_datetime(client, bq_dataset_id):
+    query = f"""
+            SELECT MAX(run_at) AS last_run_at
+            FROM `{bq_dataset_id}.bugbug_classification_runs`
+            WHERE is_ok = TRUE
+        """
+    res = client.query(query).result()
+    row = list(res)[0]
+    last_run_time = (
+        row["last_run_at"] if row["last_run_at"] is not None else "2023-11-20T00:00:00"
+    )
+    return last_run_time
+
+
+def get_reports_since_last_run(client, last_run_time):
+    query = f"""
+            SELECT
+                uuid,
+                comments as body,
+                url as title
+            FROM `moz-fx-data-shared-prod.org_mozilla_broken_site_report.user_reports`
+            WHERE comments != "" AND reported_at > "{last_run_time}"
+            ORDER BY reported_at
+        """
+    query_job = client.query(query)
+    return list(query_job.result())
+
+
+@click.command()
+@click.option("--bq_project_id", help="BigQuery project id", required=True)
+@click.option("--bq_dataset_id", help="BigQuery dataset id", required=True)
+def main(bq_project_id, bq_dataset_id):
+    client = bigquery.Client(project=bq_project_id)
+
+    # Get datetime of the last classification run
+    last_run_time = get_last_classification_datetime(client, bq_dataset_id)
+
+    # Only get reports that were filed since last classification run
+    # and have non-empty descriptions
+    rows = get_reports_since_last_run(client, last_run_time)
+
+    if not rows:
+        logging.info(
+            f"No new reports with filled descriptions were found since {last_run_time}"
+        )
+        return
+
+    objects_dict = {
+        row["uuid"]: {field: value for field, value in row.items()} for row in rows
+    }
+
+    is_ok = True
+    result_count = 0
+    try:
+        logging.info("Getting classification results from bugbug.")
+        result = get_reports_classification("invalidcompatibilityreport", objects_dict)
+        if result:
+            result_count = len(result)
+            logging.info("Saving classification results to BQ.")
+            add_classification_results(client, bq_dataset_id, result)
+
+    except Exception as e:
+        logging.error(e)
+        is_ok = False
+
+    record_classification_run(client, bq_dataset_id, is_ok, result_count)
+
+
+if __name__ == "__main__":
+    logging.getLogger().setLevel(logging.INFO)
+    main()

--- a/jobs/broken-site-report-ml/ci_job.yaml
+++ b/jobs/broken-site-report-ml/ci_job.yaml
@@ -1,0 +1,15 @@
+build-job-broken-site-report-ml:
+  docker:
+    - image: << pipeline.parameters.git-image >>
+  steps:
+    - checkout
+    - compare-branch:
+        pattern: ^jobs/broken-site-report-ml/
+    - setup_remote_docker:
+        version: << pipeline.parameters.docker-version >>
+    - run:
+        name: Build Docker image
+        command: docker build -t app:build jobs/broken-site-report-ml/
+    - run:
+        name: Test Code
+        command: docker run app:build pytest --flake8 --black

--- a/jobs/broken-site-report-ml/ci_workflow.yaml
+++ b/jobs/broken-site-report-ml/ci_workflow.yaml
@@ -1,0 +1,13 @@
+job-broken-site-report-ml:
+  jobs:
+    - build-job-broken-site-report-ml
+    - gcp-gcr/build-and-push-image:
+        context: data-eng-airflow-gcr
+        docker-context: jobs/broken-site-report-ml/
+        path: jobs/broken-site-report-ml/
+        image: broken-site-report-ml_docker_etl
+        requires:
+          - build-job-broken-site-report-ml
+        filters:
+          branches:
+            only: main

--- a/jobs/broken-site-report-ml/pytest.ini
+++ b/jobs/broken-site-report-ml/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths =
+    tests

--- a/jobs/broken-site-report-ml/requirements.txt
+++ b/jobs/broken-site-report-ml/requirements.txt
@@ -1,0 +1,6 @@
+click==8.0.4
+flake8==3.8.4
+google-cloud-bigquery==3.11.4
+pytest==6.0.2
+pytest-black==0.3.11
+pytest-flake8==1.0.6

--- a/jobs/broken-site-report-ml/setup.py
+++ b/jobs/broken-site-report-ml/setup.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+from setuptools import setup, find_packages
+
+readme = open("README.md").read()
+
+setup(
+    name="broken-site-report-ml",
+    version="0.1.0",
+    author="Mozilla Corporation",
+    packages=find_packages(include=["broken_site_report_ml"]),
+    long_description=readme,
+    include_package_data=True,
+    license="MPL 2.0",
+)

--- a/jobs/broken-site-report-ml/tests/test_main.py
+++ b/jobs/broken-site-report-ml/tests/test_main.py
@@ -1,0 +1,82 @@
+from unittest import TestCase
+from unittest.mock import Mock, patch
+from broken_site_report_ml.main import add_classification_results
+from broken_site_report_ml.main import record_classification_run
+from broken_site_report_ml.main import get_reports_classification
+
+
+class TestMain(TestCase):
+    @patch("broken_site_report_ml.main.bigquery.Client")
+    def test_add_classification_results(self, mock_bq_client):
+        mock_client = Mock()
+        mock_bq_client.return_value = mock_client
+
+        mock_job = Mock()
+        mock_client.load_table_from_json.return_value = mock_job
+        mock_job.result.return_value = None
+
+        mock_table = Mock()
+        mock_client.get_table.return_value = mock_table
+
+        bq_dataset_id = "test_dataset"
+        results = {
+            "bc1758d4-880f-4b79-b8b9-2e60b76427daa": {
+                "prob": [0.07616984844207764, 0.9238301515579224],
+                "index": 1,
+                "class": 1,
+                "extra_data": {},
+            }
+        }
+
+        add_classification_results(mock_client, bq_dataset_id, results)
+
+        mock_client.load_table_from_json.assert_called_once()
+        mock_client.get_table.assert_called_with(f"{bq_dataset_id}.labels")
+
+    @patch("broken_site_report_ml.main.bigquery.Client")
+    def test_record_classification_run(self, mock_bq_client):
+        mock_client = Mock()
+        mock_bq_client.return_value = mock_client
+
+        bq_dataset_id = "test_dataset"
+        is_ok = True
+        count = 10
+
+        record_classification_run(mock_client, bq_dataset_id, is_ok, count)
+        mock_client.insert_rows_json.assert_called_once()
+
+    @patch("broken_site_report_ml.main.classification_http_request")
+    @patch("broken_site_report_ml.main.time.sleep", Mock())
+    def test_get_reports_classification(self, mock_classification_http_request):
+        report_uuid = "bc1758d4-880f-4b79-b8b9-2e60b76427daa"
+        classification_result = {
+            "prob": [0.07616984844207764, 0.9238301515579224],
+            "index": 1,
+            "class": 1,
+            "extra_data": {},
+        }
+        mock_response = {"reports": {report_uuid: classification_result}}
+        mock_classification_http_request.return_value = mock_response
+
+        model = "test_model"
+        reports = {
+            report_uuid: {
+                "uuid": "bc1758d4-880f-4b79-b8b9-2e60b76427daa",
+                "title": "https://example.com",
+                "body": "Doesn't load",
+            }
+        }
+
+        response = get_reports_classification(model, reports)
+        self.assertEqual(
+            response,
+            {
+                report_uuid: {
+                    "prob": [0.07616984844207764, 0.9238301515579224],
+                    "index": 1,
+                    "class": 1,
+                    "extra_data": {},
+                }
+            },
+        )
+        self.assertEqual(mock_classification_http_request.call_count, 1)


### PR DESCRIPTION
This ETL job sends a batch of reports to [bugbug http service](https://github.com/mozilla/bugbug) for classification (valid/invalid) and stores results in BQ.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
