### PR TITLE
Adjust MetricHub to take segments and WHERE clause

### DIFF
--- a/jobs/kpi-forecasting/kpi_forecasting/metric_hub.py
+++ b/jobs/kpi-forecasting/kpi_forecasting/metric_hub.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from google.cloud import bigquery
 from mozanalysis.config import ConfigLoader
 from textwrap import dedent
-from typing import Optional
+from typing import Dict
 
 
 @dataclass
@@ -19,6 +19,11 @@ class MetricHub:
         slug (str): The Metric Hub slug for the metric.
         start_date (str): A 'YYYY-MM-DD' formatted-string that specifies the first
             date the metric should be queried.
+        segments (Dict): A dictionary of segments to use to group metric values.
+            The keys of the dictionary are aliases for the segment, and the
+            value is a SQL snippet that defines the segment.
+        where (str): A string specifying a condition to inject into a SQL WHERE clause,
+            to filter the data source.
         end_date (str): A 'YYYY-MM-DD' formatted-string that specifies the last
             date the metric should be queried.
         alias (str): An alias for the metric. For example, 'DAU' instead of
@@ -30,6 +35,8 @@ class MetricHub:
     app_name: str
     slug: str
     start_date: str
+    segments: Dict[str, str] = None
+    where: str = None
     end_date: str = None
     alias: str = None
     project: str = "mozdata"
@@ -52,8 +59,31 @@ class MetricHub:
             "\n", "\n" + " " * 19
         )
 
+        # Add query snippets for segments
+        if self.segments:
+            segment_select_query = []
+            for alias, sql in self.segments.items():
+                segment_select_query.append(f"  {sql} AS {alias},")
+            self.segment_select_query = "\n    ".join(segment_select_query)
+            self.segment_groupby_query = "\n ,".join(self.segments.keys())
+
+        self.where = f"AND {self.where}" if self.where else ""
+
     def query(self) -> str:
         """Build a string to query the relevant metric values from Big Query."""
+        if self.segments:
+            return dedent(
+                f"""
+                SELECT {self.submission_date_column} AS submission_date,
+                    {self.metric.select_expr} AS value,
+                    {self.segment_select_query}
+                FROM {self.from_expression}
+                WHERE {self.submission_date_column} BETWEEN '{self.start_date}' AND '{self.end_date}'
+                    {self.where}
+                GROUP BY {self.submission_date_column},
+                    {self.segment_groupby_query}
+            """
+            )
 
         return dedent(
             f"""
@@ -61,6 +91,7 @@ class MetricHub:
                    {self.metric.select_expr} AS value
               FROM {self.from_expression}
              WHERE {self.submission_date_column} BETWEEN '{self.start_date}' AND '{self.end_date}'
+                {self.where}
              GROUP BY {self.submission_date_column}
             """
         )

--- a/jobs/kpi-forecasting/kpi_forecasting/tests/test_metric_hub.py
+++ b/jobs/kpi-forecasting/kpi_forecasting/tests/test_metric_hub.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+
+from pandas import to_datetime
+from kpi_forecasting.metric_hub import MetricHub
+
+
+def test_metrichub_for_dau_kpi():
+    test_metric_hub = MetricHub(
+        app_name="multi_product",
+        slug="mobile_daily_active_users_v1",
+        start_date="2024-01-01",
+    )
+    now = to_datetime(datetime.utcnow()).date()
+
+    query = test_metric_hub.query()
+    query_where = f"WHERE submission_date BETWEEN '2024-01-01' AND '{now}'\n GROUP BY"
+
+    assert query_where in query
+    assert "\n    AND" not in query
+
+
+def test_metrichub_with_where():
+    test_metric_hub = MetricHub(
+        app_name="multi_product",
+        slug="mobile_daily_active_users_v1",
+        start_date="2024-01-01",
+        where="test_condition = condition",
+    )
+
+    query = test_metric_hub.query()
+    assert f"\n    AND {test_metric_hub.where}" in query
+
+
+def test_metrichub_with_segments():
+    test_metric_hub = MetricHub(
+        app_name="multi_product",
+        slug="mobile_daily_active_users_v1",
+        start_date="2024-01-01",
+        segments={"test_segment1": "segment1", "test_segment2": "segment2"},
+    )
+
+    query = test_metric_hub.query()
+    assert "segment1 AS test_segment1,\n     segment2 AS test_segment2" in query


### PR DESCRIPTION
Adds functionality to `MetricHub` class to take

1. a SQL WHERE clause, which acts on the underlying data source
2. a dictionary of segments, to calculate the metric of interest GROUPED BY

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
