### PR TITLE
Bump Docker image version config.yml

### DIFF
--- a/.circleci/config.template.yml
+++ b/.circleci/config.template.yml
@@ -4,7 +4,7 @@ version: 2.1
 parameters:
   docker-version:
     type: string
-    default: 20.10.18
+    default: default
   git-image:
     type: string
     default: docker:25.0.3-git

--- a/.circleci/config.template.yml
+++ b/.circleci/config.template.yml
@@ -7,7 +7,7 @@ parameters:
     default: 20.10.18
   git-image:
     type: string
-    default: docker:24.0.2-git
+    default: docker:25.0.3-git
 
 orbs:
   gcp-gcr: circleci/gcp-gcr@0.15.1

--- a/.circleci/config.template.yml
+++ b/.circleci/config.template.yml
@@ -4,6 +4,7 @@ version: 2.1
 parameters:
   docker-version:
     type: string
+    # `default` is recommended by CircleCI: https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176#what-do-i-need-to-do-2
     default: default
   git-image:
     type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,8 @@ version: 2.1
 parameters:
   docker-version:
     type: string
-    default: 20.10.18
+    # `default` is recommended by CircleCI: https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176#what-do-i-need-to-do-2
+    default: default
   git-image:
     type: string
     default: docker:25.0.3-git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ parameters:
     default: 20.10.18
   git-image:
     type: string
-    default: docker:24.0.2-git
+    default: docker:25.0.3-git
 
 orbs:
   gcp-gcr: circleci/gcp-gcr@0.15.1


### PR DESCRIPTION
CircleCI is deprecating some images in 2024

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
