### PR TITLE
Add funnel forecasting class for search forecasting

### DIFF
--- a/jobs/kpi-forecasting/kpi_forecasting/configs/model_inputs/__init__.py
+++ b/jobs/kpi-forecasting/kpi_forecasting/configs/model_inputs/__init__.py
@@ -22,6 +22,7 @@ class ProphetRegressor:
     """
 
     name: str
+    description: str
     start_date: Optional[str] = None
     end_date: Optional[str] = None
     prior_scale: Union[int, float] = 1

--- a/jobs/kpi-forecasting/kpi_forecasting/configs/model_inputs/__init__.py
+++ b/jobs/kpi-forecasting/kpi_forecasting/configs/model_inputs/__init__.py
@@ -38,22 +38,3 @@ class ProphetHoliday:
     ds: List
     lower_window: int
     upper_window: int
-
-
-@attr.s(auto_attribs=True, frozen=False)
-class ModelConfig:
-
-    metric: str
-    slug: str
-    segment: Dict[str, str]
-    start_date: Optional[str] = None
-    holidays: Optional[pd.DataFrame] = None
-    regressors: Optional[List[ProphetRegressor]] = []
-    parameters: Optional[Dict[str, Union[List[float], float]]] = None
-    cv_settings: Optional[Dict[str, str]] = {
-        "initial": "365 days",
-        "period": "30 days",
-        "horizon": "30 days",
-        "parallel": "processes",
-    }
-    trend_change: Optional[str] = ""

--- a/jobs/kpi-forecasting/kpi_forecasting/configs/model_inputs/holidays.yaml
+++ b/jobs/kpi-forecasting/kpi_forecasting/configs/model_inputs/holidays.yaml
@@ -1,5 +1,6 @@
 ---
 easter:
+  name: "easter"
   ds:
     [
       "2016-03-27",
@@ -17,41 +18,49 @@ easter:
   upper_window: 1
 
 covid_sip1:
+  name: "covid_sip1"
   ds: ["2020-03-14"]
   lower_window: 0
   upper_window: 45
 
 covid_sip11:
+  name: "covid_sip11"
   ds: ["2020-03-14"]
   lower_window: -14
   upper_window: 30
 
 covid_sip12:
+  name: "covid_sip12"
   ds: ["2020-09-15"]
   lower_window: -28
   upper_window: 30
 
 covid_esr:
+  name: "covid_esr"
   ds: ["2020-03-14"]
   lower_window: 0
   upper_window: 120
 
 covid_esr_rev:
+  name: "covid_esr_rev"
   ds: ["2020-03-14"]
   lower_window: -14
   upper_window: 105
 
 covid_esr_row_rev:
+  name: "covid_esr_row_rev"
   ds: ["2020-04-15"]
   lower_window: -45
   upper_window: 75
 
 covid_mobile_row_rev:
+  name: "covid_mobile_row_rev"
   ds: ["2020-04-01"]
   lower_window: -31
   upper_window: 60
 
 fenix_migration:
+  name: "fenix_migration"
   ds: ["2020-09-15"]
   lower_window: -28
   upper_window: 30

--- a/jobs/kpi-forecasting/kpi_forecasting/configs/model_inputs/regressors.yaml
+++ b/jobs/kpi-forecasting/kpi_forecasting/configs/model_inputs/regressors.yaml
@@ -28,3 +28,9 @@ in_covid:
   end_date: "2021-07-31"
   prior_scale: 1
   mode: "additive"
+
+ad_click_bug:
+  name: "ad_click_bug"
+  description: "Period after known bug surfaced regarding ad clicks"
+  start_date: "2023-07-01"
+  mode: "multiplicative"

--- a/jobs/kpi-forecasting/kpi_forecasting/configs/model_inputs/regressors.yaml
+++ b/jobs/kpi-forecasting/kpi_forecasting/configs/model_inputs/regressors.yaml
@@ -1,25 +1,29 @@
 ---
-post_esr_migration:
-  description: "Dates following migration of clients on old OS versions from release to ESR"
-  start_date: "2023-07-29"
-  prior_scale: 1
-  mode: "additive"
-
 addcode_topsite:
-  description: "Period that covers early impact of Covid"
+  name: "addcode_topsite"
+  description: ""
   start_date: "2020-03-14"
   end_date: "2021-07-31"
   prior_scale: 1
   mode: "multiplicative"
 
+post_esr_migration:
+  name: "post_esr_migration"
+  description: "Dates following migration of clients on old OS versions from release to ESR"
+  start_date: "2023-07-29"
+  prior_scale: 1
+  mode: "additive"
+
 after_fenix:
+  name: "after_fenix"
   description: "Dates following migration of fenix clients"
   start_date: "2020-08-15"
   prior_scale: 1
   mode: "additive"
 
 in_covid:
-  description: "Dates following migration of fenix clients"
+  name: "in_covid"
+  description: "Period that covers early impact of Covid"
   start_date: "2020-03-14"
   end_date: "2021-07-31"
   prior_scale: 1

--- a/jobs/kpi-forecasting/kpi_forecasting/configs/search_forecasting_ad_clicks.yaml
+++ b/jobs/kpi-forecasting/kpi_forecasting/configs/search_forecasting_ad_clicks.yaml
@@ -24,10 +24,11 @@ forecast_model:
         start_date: "2018-01-01"
         end_date: NULL
         holidays: ["easter", "covid_sip11"]
-        regressors: ["post_esr_migration", "in_covid"]
+        regressors: ["post_esr_migration", "in_covid", "ad_click_bug"]
         grid_parameters:
           changepoint_prior_scale: [0.001, 0.01, 0.1, 0.2, 0.5]
           changepoint_range: [0.8, 0.9]
+          n_changepoints: [25, 50]
           weekly_seasonality: True
           yearly_seasonality: True
         cv_settings:

--- a/jobs/kpi-forecasting/kpi_forecasting/configs/search_forecasting_ad_clicks.yaml
+++ b/jobs/kpi-forecasting/kpi_forecasting/configs/search_forecasting_ad_clicks.yaml
@@ -8,37 +8,42 @@ metric_hub:
 
 forecast_model:
   model_type: "funnel"
-  segment_settings:
-    desktop:
-      start_date: "2018-01-01"
-      end_date: NULL
-      holidays: ["easter", "covid_sip11"]
-      regressors: ["post_esr_migration", "in_covid"]
-      parameters:
-        changepoint_prior_scale: [0.001, 0.01, 0.1, 0.2, 0.5]
-        changepoint_range: [0.8, 0.9]
-        weekly_seasonality: True
-        yearly_seasonality: True
-        cv_settings:
-          initial: "1296 days"
-          period: "30 days"
-          horizon: "30 days"
-          parallel: "processes"
-    mobile:
-      start_date: "2019-03-01"
-      end_date: NULL
-      holidays: ["easter"]
-      regressors: ["after_fenix", "addcode_topsite", "in_covid"]
-      parameters:
-        changepoint_prior_scale: [0.001, 0.005, 0.05]
-        weekly_seasonality: True
-        yearly_seasonality: True
-        growth: "logistic"
-        cv_settings:
-          initial: "1196 days"
-          period: "30 days"
-          horizon: "30 days"
-          parallel: "processes"
+  start_date: NULL
+  end_date: NULL
+  use_holidays: False
+  parameters:
+    model_setting_split_dim: "device"
+    segment_settings:
+      desktop:
+        start_date: "2018-01-01"
+        end_date: NULL
+        holidays: ["easter", "covid_sip11"]
+        regressors: ["post_esr_migration", "in_covid"]
+        grid_parameters:
+          changepoint_prior_scale: [0.001, 0.01, 0.1, 0.2, 0.5]
+          changepoint_range: [0.8, 0.9]
+          weekly_seasonality: True
+          yearly_seasonality: True
+          cv_settings:
+            initial: "1296 days"
+            period: "30 days"
+            horizon: "30 days"
+            parallel: "processes"
+      mobile:
+        start_date: "2019-03-01"
+        end_date: NULL
+        holidays: ["easter"]
+        regressors: ["after_fenix", "addcode_topsite", "in_covid"]
+        grid_parameters:
+          changepoint_prior_scale: [0.001, 0.005, 0.05]
+          weekly_seasonality: True
+          yearly_seasonality: True
+          growth: "logistic"
+          cv_settings:
+            initial: "1196 days"
+            period: "30 days"
+            horizon: "30 days"
+            parallel: "processes"
 
 summarize:
   periods: ["day", "month"]
@@ -47,5 +52,5 @@ summarize:
 
 write_results:
   project: "moz-fx-data-shared-prod"
-  dataset: "telemetry_derived"
-  table: "kpi_forecasts_v0"
+  dataset: "revenue_cat3_analysis"
+  table: "tmp_forecast_results"

--- a/jobs/kpi-forecasting/kpi_forecasting/configs/search_forecasting_ad_clicks.yaml
+++ b/jobs/kpi-forecasting/kpi_forecasting/configs/search_forecasting_ad_clicks.yaml
@@ -36,17 +36,17 @@ forecast_model:
           period: "30 days"
           horizon: "30 days"
       mobile:
-        start_date: "2019-03-01"
+        start_date: "2022-01-01"
         end_date: NULL
         holidays: ["easter"]
-        regressors: ["after_fenix", "addcode_topsite", "in_covid"]
+        regressors: ["after_fenix", "in_covid"]
         grid_parameters:
           changepoint_prior_scale: [0.001, 0.01, 0.1, 0.2, 0.5]
           weekly_seasonality: True
           yearly_seasonality: True
           growth: "logistic"
         cv_settings:
-          initial: "931 days"
+          initial: "366 days"
           period: "30 days"
           horizon: "30 days"
 

--- a/jobs/kpi-forecasting/kpi_forecasting/configs/search_forecasting_ad_clicks.yaml
+++ b/jobs/kpi-forecasting/kpi_forecasting/configs/search_forecasting_ad_clicks.yaml
@@ -5,6 +5,12 @@ metric_hub:
   alias: "search_forecasting_ad_clicks"
   start_date: "2018-01-01"
   end_date: "last complete month"
+  segments:
+    device: "device"
+    channel: "'all'"
+    country: "CASE WHEN country = 'US' THEN 'US' ELSE 'ROW' END"
+    partner: "partner"
+  where: "partner = 'Google'"
 
 forecast_model:
   model_type: "funnel"
@@ -24,33 +30,32 @@ forecast_model:
           changepoint_range: [0.8, 0.9]
           weekly_seasonality: True
           yearly_seasonality: True
-          cv_settings:
-            initial: "1296 days"
-            period: "30 days"
-            horizon: "30 days"
-            parallel: "processes"
+        cv_settings:
+          initial: "1296 days"
+          period: "30 days"
+          horizon: "30 days"
       mobile:
         start_date: "2019-03-01"
         end_date: NULL
         holidays: ["easter"]
         regressors: ["after_fenix", "addcode_topsite", "in_covid"]
         grid_parameters:
-          changepoint_prior_scale: [0.001, 0.005, 0.05]
+          changepoint_prior_scale: [0.001, 0.01, 0.1, 0.2, 0.5]
           weekly_seasonality: True
           yearly_seasonality: True
           growth: "logistic"
-          cv_settings:
-            initial: "1196 days"
-            period: "30 days"
-            horizon: "30 days"
-            parallel: "processes"
+        cv_settings:
+          initial: "931 days"
+          period: "30 days"
+          horizon: "30 days"
 
 summarize:
   periods: ["day", "month"]
   numpy_aggregations: ["mean"]
-  percentiles: [5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95]
+  percentiles: [10, 50, 90]
 
 write_results:
-  project: "moz-fx-data-shared-prod"
-  dataset: "revenue_cat3_analysis"
-  table: "tmp_forecast_results"
+  project: "moz-fx-data-shared_prod"
+  forecast_dataset: "search_derived"
+  forecast_table: "search_funnel_forecasts"
+  components_table: "search_forecast_model_components"

--- a/jobs/kpi-forecasting/kpi_forecasting/configs/search_forecasting_ad_clicks.yaml
+++ b/jobs/kpi-forecasting/kpi_forecasting/configs/search_forecasting_ad_clicks.yaml
@@ -35,13 +35,16 @@ forecast_model:
           initial: "1296 days"
           period: "30 days"
           horizon: "30 days"
+          parallel: "processes"
       mobile:
         start_date: "2022-01-01"
         end_date: NULL
         holidays: ["easter"]
         regressors: ["after_fenix", "in_covid"]
         grid_parameters:
-          changepoint_prior_scale: [0.001, 0.01, 0.1, 0.2, 0.5]
+          changepoint_prior_scale: [.01, .1, .15, .2]
+          changepoint_range: [0.8, 0.9, 1]
+          n_changepoints: [25, 50]
           weekly_seasonality: True
           yearly_seasonality: True
           growth: "logistic"
@@ -49,6 +52,7 @@ forecast_model:
           initial: "366 days"
           period: "30 days"
           horizon: "30 days"
+          parallel: "processes"
 
 summarize:
   periods: ["day", "month"]

--- a/jobs/kpi-forecasting/kpi_forecasting/configs/search_forecasting_daily_active_users.yaml
+++ b/jobs/kpi-forecasting/kpi_forecasting/configs/search_forecasting_daily_active_users.yaml
@@ -35,17 +35,17 @@ forecast_model:
           period: "30 days"
           horizon: "30 days"
       mobile:
-        start_date: "2019-03-01"
+        start_date: "2021-01-01"
         end_date: NULL
         holidays: ["easter"]
         regressors: ["after_fenix", "in_covid"]
         grid_parameters:
-          changepoint_prior_scale: [0.001, 0.01, 0.1, 0.2, 0.5]
+          changepoint_prior_scale: [0.001, 0.01, 0.1, 0.2]
           weekly_seasonality: True
           yearly_seasonality: True
           growth: "logistic"
         cv_settings:
-          initial: "931 days"
+          initial: "366 days"
           period: "30 days"
           horizon: "30 days"
 

--- a/jobs/kpi-forecasting/kpi_forecasting/configs/search_forecasting_daily_active_users.yaml
+++ b/jobs/kpi-forecasting/kpi_forecasting/configs/search_forecasting_daily_active_users.yaml
@@ -9,36 +9,37 @@ metric_hub:
 forecast_model:
   model_type: "funnel"
   segment_settings:
+    model_setting_split_dim: "device"
     desktop:
       start_date: "2018-01-01"
       end_date: NULL
       holidays: ["easter", "covid_sip11"]
       regressors: ["post_esr_migration", "in_covid"]
-      parameters:
+      grid_parameters:
         changepoint_prior_scale: [0.001, 0.01, 0.1, 0.2, 0.5]
         changepoint_range: [0.8, 0.9]
         weekly_seasonality: True
         yearly_seasonality: True
-        cv_settings:
-          initial: "1296 days"
-          period: "30 days"
-          horizon: "30 days"
-          parallel: "processes"
+      cv_settings:
+        initial: "1296 days"
+        period: "30 days"
+        horizon: "30 days"
+        parallel: "processes"
     mobile:
       start_date: "2019-03-01"
       end_date: NULL
       holidays: ["easter"]
       regressors: ["after_fenix", "addcode_topsite", "in_covid"]
-      parameters:
+      grid_parameters:
         changepoint_prior_scale: [0.001, 0.01, 0.1, 0.2, 0.5]
         weekly_seasonality: True
         yearly_seasonality: True
         growth: "logistic"
-        cv_settings:
-          initial: "1196 days"
-          period: "30 days"
-          horizon: "30 days"
-          parallel: "processes"
+      cv_settings:
+        initial: "1196 days"
+        period: "30 days"
+        horizon: "30 days"
+        parallel: "processes"
 
 summarize:
   periods: ["day", "month"]
@@ -47,5 +48,5 @@ summarize:
 
 write_results:
   project: "moz-fx-data-shared-prod"
-  dataset: "telemetry_derived"
-  table: "kpi_forecasts_v0"
+  dataset: "revenue_cat3_analysis"
+  table: "tmp_forecast_results"

--- a/jobs/kpi-forecasting/kpi_forecasting/configs/search_forecasting_daily_active_users.yaml
+++ b/jobs/kpi-forecasting/kpi_forecasting/configs/search_forecasting_daily_active_users.yaml
@@ -34,13 +34,14 @@ forecast_model:
           initial: "1296 days"
           period: "30 days"
           horizon: "30 days"
+          parallel: "processes"
       mobile:
         start_date: "2021-01-01"
         end_date: NULL
         holidays: ["easter"]
         regressors: ["after_fenix", "in_covid"]
         grid_parameters:
-          changepoint_prior_scale: [0.001, 0.01, 0.1, 0.2]
+          changepoint_prior_scale: [0.001, 0.01, 0.1]
           weekly_seasonality: True
           yearly_seasonality: True
           growth: "logistic"
@@ -48,6 +49,7 @@ forecast_model:
           initial: "366 days"
           period: "30 days"
           horizon: "30 days"
+          parallel: "processes"
 
 summarize:
   periods: ["day", "month"]

--- a/jobs/kpi-forecasting/kpi_forecasting/configs/search_forecasting_daily_active_users.yaml
+++ b/jobs/kpi-forecasting/kpi_forecasting/configs/search_forecasting_daily_active_users.yaml
@@ -5,48 +5,57 @@ metric_hub:
   alias: "search_forecasting_daily_active_users"
   start_date: "2018-01-01"
   end_date: "last complete month"
+  segments:
+    device: "device"
+    channel: "'all'"
+    country: "CASE WHEN country = 'US' THEN 'US' ELSE 'ROW' END"
+    partner: "partner"
+  where: "partner = 'Google'"
 
 forecast_model:
   model_type: "funnel"
-  segment_settings:
+  start_date: NULL
+  end_date: NULL
+  use_holidays: False
+  parameters:
     model_setting_split_dim: "device"
-    desktop:
-      start_date: "2018-01-01"
-      end_date: NULL
-      holidays: ["easter", "covid_sip11"]
-      regressors: ["post_esr_migration", "in_covid"]
-      grid_parameters:
-        changepoint_prior_scale: [0.001, 0.01, 0.1, 0.2, 0.5]
-        changepoint_range: [0.8, 0.9]
-        weekly_seasonality: True
-        yearly_seasonality: True
-      cv_settings:
-        initial: "1296 days"
-        period: "30 days"
-        horizon: "30 days"
-        parallel: "processes"
-    mobile:
-      start_date: "2019-03-01"
-      end_date: NULL
-      holidays: ["easter"]
-      regressors: ["after_fenix", "addcode_topsite", "in_covid"]
-      grid_parameters:
-        changepoint_prior_scale: [0.001, 0.01, 0.1, 0.2, 0.5]
-        weekly_seasonality: True
-        yearly_seasonality: True
-        growth: "logistic"
-      cv_settings:
-        initial: "1196 days"
-        period: "30 days"
-        horizon: "30 days"
-        parallel: "processes"
+    segment_settings:
+      desktop:
+        start_date: "2018-01-01"
+        end_date: NULL
+        holidays: ["easter", "covid_sip11"]
+        regressors: ["post_esr_migration", "in_covid"]
+        grid_parameters:
+          changepoint_prior_scale: [0.001, 0.01, 0.1, 0.2, 0.5]
+          changepoint_range: [0.8, 0.9]
+          weekly_seasonality: True
+          yearly_seasonality: True
+        cv_settings:
+          initial: "1296 days"
+          period: "30 days"
+          horizon: "30 days"
+      mobile:
+        start_date: "2019-03-01"
+        end_date: NULL
+        holidays: ["easter"]
+        regressors: ["after_fenix", "in_covid"]
+        grid_parameters:
+          changepoint_prior_scale: [0.001, 0.01, 0.1, 0.2, 0.5]
+          weekly_seasonality: True
+          yearly_seasonality: True
+          growth: "logistic"
+        cv_settings:
+          initial: "931 days"
+          period: "30 days"
+          horizon: "30 days"
 
 summarize:
   periods: ["day", "month"]
   numpy_aggregations: ["mean"]
-  percentiles: [5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95]
+  percentiles: [10, 50, 90]
 
 write_results:
-  project: "moz-fx-data-shared-prod"
-  dataset: "revenue_cat3_analysis"
-  table: "tmp_forecast_results"
+  project: "moz-fx-data-shared_prod"
+  forecast_dataset: "search_derived"
+  forecast_table: "search_funnel_forecasts"
+  components_table: "search_forecast_model_components"

--- a/jobs/kpi-forecasting/kpi_forecasting/configs/search_forecasting_search_count.yaml
+++ b/jobs/kpi-forecasting/kpi_forecasting/configs/search_forecasting_search_count.yaml
@@ -34,13 +34,14 @@ forecast_model:
           initial: "1296 days"
           period: "30 days"
           horizon: "30 days"
+          parallel: "processes"
       mobile:
         start_date: "2020-01-01"
         end_date: NULL
         holidays: ["easter"]
         regressors: ["after_fenix", "in_covid"]
         grid_parameters:
-          changepoint_prior_scale: [0.001, 0.01, 0.1, 0.2]
+          changepoint_prior_scale: [0.001, 0.01, 0.1]
           weekly_seasonality: True
           yearly_seasonality: True
           growth: "logistic"
@@ -48,6 +49,7 @@ forecast_model:
           initial: "366 days"
           period: "30 days"
           horizon: "30 days"
+          parallel: "processes"
 
 summarize:
   periods: ["day", "month"]

--- a/jobs/kpi-forecasting/kpi_forecasting/configs/search_forecasting_search_count.yaml
+++ b/jobs/kpi-forecasting/kpi_forecasting/configs/search_forecasting_search_count.yaml
@@ -9,36 +9,37 @@ metric_hub:
 forecast_model:
   model_type: "funnel"
   segment_settings:
+    model_setting_split_dim: "device"
     desktop:
       start_date: "2018-01-01"
       end_date: NULL
       holidays: ["easter", "covid_sip11"]
       regressors: ["post_esr_migration", "in_covid"]
-      parameters:
+      grid_parameters:
         changepoint_prior_scale: [0.001, 0.01, 0.1, 0.2, 0.5]
         changepoint_range: [0.8, 0.9]
         weekly_seasonality: True
         yearly_seasonality: True
-        cv_settings:
-          initial: "1296 days"
-          period: "30 days"
-          horizon: "30 days"
-          parallel: "processes"
+      cv_settings:
+        initial: "1296 days"
+        period: "30 days"
+        horizon: "30 days"
+        parallel: "processes"
     mobile:
       start_date: "2019-03-01"
       end_date: NULL
       holidays: ["easter"]
       regressors: ["after_fenix", "addcode_topsite", "in_covid"]
-      parameters:
+      grid_parameters:
         changepoint_prior_scale: [0.001, 0.01, 0.1, 0.2, 0.5]
         weekly_seasonality: True
         yearly_seasonality: True
         growth: "logistic"
-        cv_settings:
-          initial: "1196 days"
-          period: "30 days"
-          horizon: "30 days"
-          parallel: "processes"
+      cv_settings:
+        initial: "1196 days"
+        period: "30 days"
+        horizon: "30 days"
+        parallel: "processes"
 
 summarize:
   periods: ["day", "month"]
@@ -47,5 +48,5 @@ summarize:
 
 write_results:
   project: "moz-fx-data-shared-prod"
-  dataset: "telemetry_derived"
-  table: "kpi_forecasts_v0"
+  dataset: "revenue_cat3_analysis"
+  table: "tmp_forecast_results"

--- a/jobs/kpi-forecasting/kpi_forecasting/configs/search_forecasting_search_count.yaml
+++ b/jobs/kpi-forecasting/kpi_forecasting/configs/search_forecasting_search_count.yaml
@@ -35,17 +35,17 @@ forecast_model:
           period: "30 days"
           horizon: "30 days"
       mobile:
-        start_date: "2019-03-01"
+        start_date: "2020-01-01"
         end_date: NULL
         holidays: ["easter"]
         regressors: ["after_fenix", "in_covid"]
         grid_parameters:
-          changepoint_prior_scale: [0.001, 0.01, 0.1, 0.2, 0.5]
+          changepoint_prior_scale: [0.001, 0.01, 0.1, 0.2]
           weekly_seasonality: True
           yearly_seasonality: True
           growth: "logistic"
         cv_settings:
-          initial: "931 days"
+          initial: "366 days"
           period: "30 days"
           horizon: "30 days"
 

--- a/jobs/kpi-forecasting/kpi_forecasting/configs/search_forecasting_search_count.yaml
+++ b/jobs/kpi-forecasting/kpi_forecasting/configs/search_forecasting_search_count.yaml
@@ -5,48 +5,57 @@ metric_hub:
   alias: "search_forecasting_search_count"
   start_date: "2018-01-01"
   end_date: "last complete month"
+  segments:
+    device: "device"
+    channel: "'all'"
+    country: "CASE WHEN country = 'US' THEN 'US' ELSE 'ROW' END"
+    partner: "partner"
+  where: "partner = 'Google'"
 
 forecast_model:
   model_type: "funnel"
-  segment_settings:
+  start_date: NULL
+  end_date: NULL
+  use_holidays: False
+  parameters:
     model_setting_split_dim: "device"
-    desktop:
-      start_date: "2018-01-01"
-      end_date: NULL
-      holidays: ["easter", "covid_sip11"]
-      regressors: ["post_esr_migration", "in_covid"]
-      grid_parameters:
-        changepoint_prior_scale: [0.001, 0.01, 0.1, 0.2, 0.5]
-        changepoint_range: [0.8, 0.9]
-        weekly_seasonality: True
-        yearly_seasonality: True
-      cv_settings:
-        initial: "1296 days"
-        period: "30 days"
-        horizon: "30 days"
-        parallel: "processes"
-    mobile:
-      start_date: "2019-03-01"
-      end_date: NULL
-      holidays: ["easter"]
-      regressors: ["after_fenix", "addcode_topsite", "in_covid"]
-      grid_parameters:
-        changepoint_prior_scale: [0.001, 0.01, 0.1, 0.2, 0.5]
-        weekly_seasonality: True
-        yearly_seasonality: True
-        growth: "logistic"
-      cv_settings:
-        initial: "1196 days"
-        period: "30 days"
-        horizon: "30 days"
-        parallel: "processes"
+    segment_settings:
+      desktop:
+        start_date: "2018-01-01"
+        end_date: NULL
+        holidays: ["easter", "covid_sip11"]
+        regressors: ["post_esr_migration", "in_covid"]
+        grid_parameters:
+          changepoint_prior_scale: [0.001, 0.01, 0.1, 0.2, 0.5]
+          changepoint_range: [0.8, 0.9]
+          weekly_seasonality: True
+          yearly_seasonality: True
+        cv_settings:
+          initial: "1296 days"
+          period: "30 days"
+          horizon: "30 days"
+      mobile:
+        start_date: "2019-03-01"
+        end_date: NULL
+        holidays: ["easter"]
+        regressors: ["after_fenix", "in_covid"]
+        grid_parameters:
+          changepoint_prior_scale: [0.001, 0.01, 0.1, 0.2, 0.5]
+          weekly_seasonality: True
+          yearly_seasonality: True
+          growth: "logistic"
+        cv_settings:
+          initial: "931 days"
+          period: "30 days"
+          horizon: "30 days"
 
 summarize:
   periods: ["day", "month"]
   numpy_aggregations: ["mean"]
-  percentiles: [5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95]
+  percentiles: [10, 50, 90]
 
 write_results:
-  project: "moz-fx-data-shared-prod"
-  dataset: "revenue_cat3_analysis"
-  table: "tmp_forecast_results"
+  project: "moz-fx-data-shared_prod"
+  forecast_dataset: "search_derived"
+  forecast_table: "search_funnel_forecasts"
+  components_table: "search_forecast_model_components"

--- a/jobs/kpi-forecasting/kpi_forecasting/metric_hub.py
+++ b/jobs/kpi-forecasting/kpi_forecasting/metric_hub.py
@@ -2,6 +2,7 @@ import pandas as pd
 
 from dataclasses import dataclass
 from datetime import datetime
+from dotmap import DotMap
 from google.cloud import bigquery
 from mozanalysis.config import ConfigLoader
 from textwrap import dedent
@@ -37,7 +38,7 @@ class MetricHub:
     app_name: str
     slug: str
     start_date: str
-    segments: Dict[str, str] = None
+    segments: DotMap = None
     where: str = None
     end_date: str = None
     alias: str = None
@@ -67,7 +68,8 @@ class MetricHub:
 
         if self.segments:
             segment_select_query = []
-            for alias, sql in self.segments.items():
+            segments = dict(self.segments)
+            for alias, sql in segments.items():
                 segment_select_query.append(f"  {sql} AS {alias},")
             self.segment_select_query = "," + "\n              ".join(
                 segment_select_query

--- a/jobs/kpi-forecasting/kpi_forecasting/models/funnel_forecast.py
+++ b/jobs/kpi-forecasting/kpi_forecasting/models/funnel_forecast.py
@@ -584,12 +584,12 @@ class FunnelForecast(BaseForecast):
                 self.components_df.dtypes == object
             ].index.tolist()
             self.components_df["metric_slug"] = self.metric_hub.slug
-            self.components_df["trained_at"] = self.trained_at
+            self.components_df["forecast_trained_at"] = self.trained_at
 
             schema = [
                 bigquery.SchemaField("submission_date", bq_types.DATE),
                 bigquery.SchemaField("metric_slug", bq_types.STRING),
-                bigquery.SchemaField("trained_at", bq_types.TIMESTAMP),
+                bigquery.SchemaField("forecast_trained_at", bq_types.TIMESTAMP),
             ]
             schema += [
                 bigquery.SchemaField(col, bq_types.STRING) for col in string_cols

--- a/jobs/kpi-forecasting/kpi_forecasting/models/funnel_forecast.py
+++ b/jobs/kpi-forecasting/kpi_forecasting/models/funnel_forecast.py
@@ -325,6 +325,9 @@ class FunnelForecast(BaseForecast):
 
             df_bias = df_cv.groupby("cutoff")[["yhat", "y"]].sum().reset_index()
             df_bias["pcnt_bias"] = df_bias["yhat"] / df_bias["y"] - 1
+            # Prophet splits the historical data when doing cross validation using
+            # cutoffs. The `.tail(3)` limits the periods we consider for the best
+            # parameters to the 3 most recent cutoff periods.
             bias.append(df_bias.tail(3)["pcnt_bias"].mean())
 
         min_abs_bias_index = np.argmin(np.abs(bias))
@@ -400,7 +403,9 @@ class FunnelForecast(BaseForecast):
         ]
 
         # join observed data to components df, which allows for calc of intra-sample
-        ## error rates and how components resulted in those predictions
+        # error rates and how components resulted in those predictions. The `fillna`
+        # call will fill the missing y values for forecasted dates, where only yhat
+        # is available.
         components_df = components_df.merge(
             segment_settings.segment_model.history[["ds", "y"]],
             on="ds",

--- a/jobs/kpi-forecasting/kpi_forecasting/models/funnel_forecast.py
+++ b/jobs/kpi-forecasting/kpi_forecasting/models/funnel_forecast.py
@@ -222,14 +222,15 @@ class FunnelForecast(BaseForecast):
 
         # build training dataframe
         if task == "train":
+
+            # find indices in observed_df for rows that exactly match segment dict
+            segment_historical_indices = (
+                self.observed_df[list(segment_settings.segment)]
+                == pd.Series(segment_settings.segment)
+            ).all(axis=1)
             df = (
                 self.observed_df.loc[
-                    (  # filter observed_df to rows that exactly match segment dict
-                        (
-                            self.observed_df[list(segment_settings.segment)]
-                            == pd.Series(segment_settings.segment)
-                        ).all(axis=1)
-                    )
+                    (segment_historical_indices)
                     & (  # filter observed_df if segment start date > metric_hub start date
                         self.observed_df["submission_date"]
                         >= datetime.strptime(
@@ -493,16 +494,18 @@ class FunnelForecast(BaseForecast):
         segment_observed_start_date = datetime.strptime(
             segment_settings.start_date, "%Y-%m-%d"
         ).date()
+
+        # find indices in observed_df for rows that exactly match segment dict
+        segment_historical_indices = (
+            self.observed_df[list(segment_settings.segment)]
+            == pd.Series(segment_settings.segment)
+        ).all(axis=1)
+
         # aggregate metric to the correct date period (day, month, year)
         observed_summarized = pdx.aggregate_to_period(
             (
                 self.observed_df.loc[
-                    (
-                        (
-                            self.observed_df[list(segment_settings.segment)]
-                            == pd.Series(segment_settings.segment)
-                        ).all(axis=1)
-                    )
+                    (segment_historical_indices)
                     & (
                         self.observed_df["submission_date"]
                         >= segment_observed_start_date

--- a/jobs/kpi-forecasting/kpi_forecasting/tests/test_data/test_funnel_config.yaml
+++ b/jobs/kpi-forecasting/kpi_forecasting/tests/test_data/test_funnel_config.yaml
@@ -1,0 +1,62 @@
+---
+metric_hub:
+  app_name: "multi_product"
+  slug: "search_forecasting_ad_clicks"
+  alias: "search_forecasting_ad_clicks"
+  start_date: "2018-01-01"
+  end_date: "last complete month"
+  segments:
+    device: "device"
+    channel: "'all' AS channel"
+    country: "CASE WHEN country = 'US' THEN 'US' ELSE 'ROW' END AS country"
+  where: "partner_name = 'Google'"
+
+forecast_model:
+  model_type: "funnel"
+  start_date: NULL
+  end_date: NULL
+  use_holidays: False
+  parameters:
+    model_setting_split_dim: "device"
+    segment_settings:
+      desktop:
+        start_date: "2018-01-01"
+        end_date: NULL
+        holidays: ["easter", "covid_sip11"]
+        regressors: ["post_esr_migration", "in_covid"]
+        grid_parameters:
+          changepoint_prior_scale: [0.001, 0.01, 0.1, 0.2, 0.5]
+          changepoint_range: [0.8, 0.9]
+          weekly_seasonality: True
+          yearly_seasonality: True
+          cv_settings:
+            initial: "1296 days"
+            period: "30 days"
+            horizon: "30 days"
+            parallel: "processes"
+      mobile:
+        start_date: "2019-03-01"
+        end_date: NULL
+        holidays: ["easter"]
+        regressors: ["after_fenix", "addcode_topsite", "in_covid"]
+        grid_parameters:
+          changepoint_prior_scale: [0.001, 0.005, 0.05]
+          weekly_seasonality: True
+          yearly_seasonality: True
+          growth: "logistic"
+          cv_settings:
+            initial: "1196 days"
+            period: "30 days"
+            horizon: "30 days"
+            parallel: "processes"
+
+summarize:
+  periods: ["day", "month"]
+  numpy_aggregations: ["mean"]
+  percentiles: [5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95]
+
+write_results:
+  project: "moz-fx-data-shared-prod"
+  dataset: "mbowerman"
+  table: "test_prod_set"
+  components_table: "test_prod_components"

--- a/jobs/kpi-forecasting/kpi_forecasting/tests/test_funnel_forecast.py
+++ b/jobs/kpi-forecasting/kpi_forecasting/tests/test_funnel_forecast.py
@@ -1,0 +1,2 @@
+from kpi_forecasting.models import funnel_forecast
+from kpi_forecasting.metric_hub import MetricHub

--- a/jobs/kpi-forecasting/requirements.txt
+++ b/jobs/kpi-forecasting/requirements.txt
@@ -47,7 +47,7 @@ Pillow==9.5.0
 platformdirs==3.5.3
 plotly==5.15.0
 pluggy==1.0.0
-prophet==1.1.4
+prophet==1.1.5
 proto-plus==1.22.2
 protobuf==4.23.3
 pyarrow==12.0.1


### PR DESCRIPTION
Adds `funnel_forecast.py`, which contains the class to produce search funnel forecasts. Goal is to have this PR reviewed and merged by March 15th.

TODO:
  1. Add tests for new forecast class
  2. Check discrepancy between posterior median and components table `yhat`
  3. Set up example notebook with training, scoring, and validation

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
