### PR TITLE
Fixes #179 - Change broken_site_report_ml ETL to use live table

### DIFF
--- a/jobs/broken-site-report-ml/broken_site_report_ml/main.py
+++ b/jobs/broken-site-report-ml/broken_site_report_ml/main.py
@@ -147,7 +147,7 @@ def get_reports_since_last_run(client, last_run_time):
                 uuid,
                 comments as body,
                 url as title
-            FROM `moz-fx-data-shared-prod.org_mozilla_broken_site_report.user_reports`
+            FROM `moz-fx-data-shared-prod.org_mozilla_broken_site_report.user_reports_live`
             WHERE reported_at >= "{last_run_time}" AND comments != ""
             ORDER BY reported_at
         """
@@ -162,7 +162,7 @@ def get_missed_reports(client, last_run_time, bq_dataset_id):
                 reports.comments as body,
                 reports.url as title
             FROM
-            `moz-fx-data-shared-prod.org_mozilla_broken_site_report.user_reports`
+            `moz-fx-data-shared-prod.org_mozilla_broken_site_report.user_reports_live`
             AS reports
             LEFT JOIN `{bq_dataset_id}.bugbug_predictions` AS predictions
             ON reports.uuid = predictions.report_uuid


### PR DESCRIPTION
This depends on the live view that should be created in https://github.com/mozilla/bigquery-etl/pull/5267

I'd like to change the ETL to use `org_mozilla_broken_site_report.user_reports_live` instead of `org_mozilla_broken_site_report.user_reports`.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
