### PR TITLE
Fixes #185 - Fix missing title error for broken-site-report-ml job

### DIFF
--- a/jobs/broken-site-report-ml/broken_site_report_ml/main.py
+++ b/jobs/broken-site-report-ml/broken_site_report_ml/main.py
@@ -146,7 +146,7 @@ def get_reports_since_last_run(client, last_run_time):
             SELECT
                 uuid,
                 comments as body,
-                url as title
+                COALESCE(url, uuid) as title
             FROM `moz-fx-data-shared-prod.org_mozilla_broken_site_report.user_reports_live`
             WHERE reported_at >= "{last_run_time}" AND comments != ""
             ORDER BY reported_at
@@ -160,7 +160,7 @@ def get_missed_reports(client, last_run_time, bq_dataset_id):
             SELECT
                 reports.uuid,
                 reports.comments as body,
-                reports.url as title
+                COALESCE(reports.url, reports.uuid) as title
             FROM
             `moz-fx-data-shared-prod.org_mozilla_broken_site_report.user_reports_live`
             AS reports
@@ -213,8 +213,10 @@ def main(bq_project_id, bq_dataset_id):
     except Exception as e:
         logging.error(e)
         is_ok = False
+        raise
 
-    record_classification_run(client, bq_dataset_id, is_ok, result_count)
+    finally:
+        record_classification_run(client, bq_dataset_id, is_ok, result_count)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I'm using reports urls as report "title" when submitting a request to bugbug. Since titles are required in the schema validator, the batch request files with an error if any of the reports are missing a url (which is rare, but happens):

```
models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error: BAD REQUEST for url: https://bugbug.herokuapp.com/invalidcompatibilityreport/predict/broken_site_report/batch
```

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
