### PR TITLE
Fixes #197 - Add translation step to the broken-site-report-ml job

### DIFF
--- a/jobs/broken-site-report-ml/.flake8
+++ b/jobs/broken-site-report-ml/.flake8
@@ -1,2 +1,3 @@
 [flake8]
 max-line-length = 88
+ignore = E203

--- a/jobs/broken-site-report-ml/README.md
+++ b/jobs/broken-site-report-ml/README.md
@@ -8,7 +8,7 @@ This script is intended to be run in a docker container.
 Build the docker image with:
 
 ```sh
-docker build -t python-template-job .
+docker build -t broken-site-report-ml .
 ```
 
 To run locally, install dependencies with:
@@ -17,10 +17,11 @@ To run locally, install dependencies with:
 pip install -r requirements.txt
 ```
 
-Run the script with 
+And then run the script after authentication with gcloud:
 
 ```sh   
-python3 -m python_template_job.main
+gcloud auth application-default login
+python3 broken_site_report_ml/main.py --bq_project_id=<your_project_id> --bq_dataset_id=<your_dataset_id>
 ```
 
 ## Development
@@ -40,6 +41,6 @@ pytest --black --flake8
 or
 
 ```sh
-flake8 python_template_job/ tests/
-black --diff python_template_job/ tests/
+flake8 broken_site_report/ tests/
+black --diff broken_site_report/ tests/
 ```

--- a/jobs/broken-site-report-ml/tests/test_main.py
+++ b/jobs/broken-site-report-ml/tests/test_main.py
@@ -3,6 +3,9 @@ from unittest.mock import Mock, patch
 from broken_site_report_ml.main import add_classification_results
 from broken_site_report_ml.main import record_classification_run
 from broken_site_report_ml.main import get_reports_classification
+from broken_site_report_ml.main import deduplicate_reports
+from broken_site_report_ml.main import translate_reports
+from google.cloud.bigquery import Row
 
 
 class TestMain(TestCase):
@@ -80,3 +83,147 @@ class TestMain(TestCase):
             },
         )
         self.assertEqual(mock_classification_http_request.call_count, 1)
+
+
+class TestDeduplicateTranslateReports(TestCase):
+    def setUp(self):
+        self.schema = {"uuid": 0, "body": 1, "title": 2, "translated_text": 3}
+        self.reports = [
+            Row(
+                (
+                    "bc1758d4-880f-4b79-b8b9-2e60b76427daa",
+                    "test message",
+                    "https://example.com",
+                    "",
+                ),
+                self.schema,
+            ),
+            Row(
+                (
+                    "bc1758d4-880f-4b79-b8b9-2e60b76427daa",
+                    "test message",
+                    "https://example.com",
+                    "",
+                ),
+                self.schema,
+            ),
+            Row(
+                (
+                    "ac1958d4-880f-4b79-b8b9-2e60b76427daa",
+                    "navegador no compatible",
+                    "https://example.com/es",
+                    "",
+                ),
+                self.schema,
+            ),
+            Row(
+                (
+                    "ww1958d4-440f-4479-b8b9-2e60b76427daa",
+                    "图片记载不出来，搜索框无法使用\n",
+                    "https://example.com",
+                    "The picture cannot be recorded\n",
+                ),
+                self.schema,
+            ),
+        ]
+
+    def test_deduplication(self):
+        deduplicated = deduplicate_reports(self.reports)
+        expected = [
+            {
+                "uuid": "bc1758d4-880f-4b79-b8b9-2e60b76427daa",
+                "body": "test message",
+                "title": "https://example.com",
+                "translated_text": "",
+            },
+            {
+                "uuid": "ac1958d4-880f-4b79-b8b9-2e60b76427daa",
+                "body": "navegador no compatible",
+                "title": "https://example.com/es",
+                "translated_text": "",
+            },
+            {
+                "uuid": "ww1958d4-440f-4479-b8b9-2e60b76427daa",
+                "body": "图片记载不出来，搜索框无法使用\n",
+                "title": "https://example.com",
+                "translated_text": "The picture cannot be recorded\n",
+            },
+        ]
+        self.assertEqual(len(deduplicated), 3)
+        self.assertEqual(deduplicate_reports(self.reports), expected)
+
+    def test_empty_list(self):
+        deduplicated = deduplicate_reports([])
+        self.assertEqual(len(deduplicated), 0, "Should handle empty list without error")
+
+    @patch("broken_site_report_ml.main.bigquery.Client")
+    @patch("broken_site_report_ml.main.translate_by_uuid")
+    def test_translate_reports(self, mock_translate_by_uuid, mock_bq_client):
+        mock_client = Mock()
+        mock_bq_client.return_value = mock_client
+
+        schema = {"uuid": 0, "language_code": 1, "translated_text": 2, "status": 3}
+        mock_translate_by_uuid.return_value = [
+            Row(
+                ("bc1758d4-880f-4b79-b8b9-2e60b76427daa", "en", "test message", ""),
+                schema,
+            ),
+            Row(
+                (
+                    "ac1958d4-880f-4b79-b8b9-2e60b76427daa",
+                    "es",
+                    "navegador no compatible",
+                    "",
+                ),
+                schema,
+            ),
+        ]
+
+        mock_bq_dataset_id = "test_dataset"
+        reports = [
+            {
+                "uuid": "bc1758d4-880f-4b79-b8b9-2e60b76427daa",
+                "body": "test message",
+                "title": "https://example.com",
+                "translated_text": "",
+            },
+            {
+                "uuid": "ac1958d4-880f-4b79-b8b9-2e60b76427daa",
+                "body": "navegador no compatible",
+                "title": "https://example.com/es",
+                "translated_text": "",
+            },
+            {
+                "uuid": "ww1958d4-440f-4479-b8b9-2e60b76427daa",
+                "body": "图片记载不出来，搜索框无法使用\n",
+                "title": "https://example.com",
+                "translated_text": "The picture cannot be recorded\n",
+            },
+        ]
+
+        expected_uuids = [
+            "bc1758d4-880f-4b79-b8b9-2e60b76427daa",
+            "ac1958d4-880f-4b79-b8b9-2e60b76427daa",
+        ]
+        result = translate_reports(mock_client, reports, mock_bq_dataset_id)
+
+        mock_translate_by_uuid.assert_called_once_with(
+            mock_client, expected_uuids, mock_bq_dataset_id
+        )
+        self.assertEqual(
+            result,
+            {
+                "bc1758d4-880f-4b79-b8b9-2e60b76427daa": {
+                    "uuid": "bc1758d4-880f-4b79-b8b9-2e60b76427daa",
+                    "language_code": "en",
+                    "translated_text": "test message",
+                    "status": "",
+                },
+                "ac1958d4-880f-4b79-b8b9-2e60b76427daa": {
+                    "uuid": "ac1958d4-880f-4b79-b8b9-2e60b76427daa",
+                    "language_code": "es",
+                    "translated_text": "navegador no compatible",
+                    "status": "",
+                },
+            },
+        )


### PR DESCRIPTION
At this step the reports are translated using ML.TRANSLATE and translated text is used for classification and stored in a separate table.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
