### PR TITLE
fix(DAG): Workday-XMatters [ASP-4631] - Raising an error

### DIFF
--- a/jobs/eam-integrations/scripts/api/XMatters/secrets_xmatters.py
+++ b/jobs/eam-integrations/scripts/api/XMatters/secrets_xmatters.py
@@ -4,7 +4,7 @@ config = {
     "proxies": {},
     "xm_client_id": os.environ.get("XMATTERS_CLIENT_ID", ""),
     "xm_username": os.environ.get("XMATTERS_USERNAME", ""),
-    "xm_password": os.environ.get("XMATTERS_PASSWORD", ""),
+    "xm_password": os.environ.get("XMATTERS_PASSWORD1", ""),
     "url": os.environ.get("XMATTERS_URL", ""),
     "supervisor_id": os.environ.get("XMATTERS_SUPERVISOR_ID", ""),
 }


### PR DESCRIPTION
Description
Changing the xm_password environment name to raise an error to test on_failure function in the dag.

JIRA TICKET ASP [4631](https://mozilla-hub.atlassian.net/browse/ASP-4631)
JIRA EPIC TICKET [ASP-4509](https://mozilla-hub.atlassian.net/browse/ASP-4509)

[ASP-4509]: https://mozilla-hub.atlassian.net/browse/ASP-4509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ