### PR TITLE
[dap dev ppa collector] remove impression and click counts, adjust conversion counts offset

### DIFF
--- a/jobs/dap-collector-ppa-dev/Dockerfile
+++ b/jobs/dap-collector-ppa-dev/Dockerfile
@@ -9,7 +9,7 @@ RUN apt update && apt --yes install curl
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH $HOME/.cargo/bin:$PATH
 
-RUN git clone --depth 1 https://github.com/divviup/janus.git --branch '0.6.6'
+RUN git clone --depth 1 https://github.com/divviup/janus.git --branch '0.7.20'
 RUN cd janus && cargo build -r -p janus_tools --bin collect
 
 ######### next stage

--- a/jobs/dap-collector-ppa-dev/README.md
+++ b/jobs/dap-collector-ppa-dev/README.md
@@ -16,9 +16,10 @@ docker build -t dap-collector-ppa-dev .
 To run locally, install dependencies with (in jobs/dap-collector):
 
 ```sh
-git clone --depth 1 https://github.com/divviup/janus.git --branch '0.6.6'
+git clone --depth 1 https://github.com/divviup/janus.git --branch '0.7.20'
 cd janus
-cargo build -p janus_collector --example collect
+cargo build -r -p janus_tools --bin collect
+cp target/release/collect ../dap_collector_ppa_dev/
 cd ..
 pip install -r requirements.txt
 ```

--- a/jobs/dap-collector-ppa-dev/dap_collector_ppa_dev/main.py
+++ b/jobs/dap-collector-ppa-dev/dap_collector_ppa_dev/main.py
@@ -20,8 +20,6 @@ ADS_SCHEMA = [
     bigquery.SchemaField("task_size", "INTEGER", mode="REQUIRED"),
     bigquery.SchemaField("task_id", "STRING", mode="REQUIRED"),
     bigquery.SchemaField("task_index", "INTEGER", mode="REQUIRED"),
-    bigquery.SchemaField("impression_count", "INTEGER", mode="REQUIRED"),
-    bigquery.SchemaField("click_count", "INTEGER", mode="REQUIRED"),
     bigquery.SchemaField("conversion_count", "INTEGER", mode="REQUIRED"),
 ]
 REPORT_SCHEMA = [
@@ -132,9 +130,7 @@ async def collect_once(task, timestamp, duration, hpke_private_key, auth_token):
                         cnt["task_id"] = task["task_id"]
                         cnt["task_index"] = i
                         cnt["task_size"] = ad["debug"]["taskSize"]
-                        cnt["impression_count"] = entries[i]
-                        cnt["click_count"] = entries[i + TASK_AD_SIZE]
-                        cnt["conversion_count"] = entries[i + (TASK_AD_SIZE * 2)]
+                        cnt["conversion_count"] = entries[i]
 
                         res["counts"].append(cnt)
             elif line.startswith("Number of reports:"):


### PR DESCRIPTION
Checklist for reviewer:

[AE-364](https://mozilla-hub.atlassian.net/browse/AE-364)

This adjusts the ppa dev collector in preparation to creating the corresponding prod collector.

- clicks will not be reported via ppa
- impressions will not be reported via ppa
- adjust the offset of the vector given the other counts are not reported
- added a couple more data points to facilitate aggregations in the reporting
- adjusted the ads.json format to remove unused fields and organize fields that stayed

### testing
running locally while gloud authenticated to simulate the behavior when run by airflow. Currently it is running and emitting records into the `reports` table, but not to the `measurements` table.

After updating the version of janus collector being used here, then I was able to run this and see records get written to the dev tables.


- [X] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)
- [x] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [x] Ensure the container image will be using permissions granted to [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/) responsibly.
