### PR TITLE
PPA Prod adjust how secrets are handled

### DIFF
--- a/jobs/dap-collector-ppa-prod/dap_collector_ppa_prod/main.py
+++ b/jobs/dap-collector-ppa-prod/dap_collector_ppa_prod/main.py
@@ -2,6 +2,7 @@ import asyncio
 import click
 import datetime
 import math
+import os
 import time
 
 from google.cloud import bigquery
@@ -251,16 +252,6 @@ def store_data(results, bqclient, table_id):
     required=True,
 )
 @click.option(
-    "--auth-token",
-    help="HTTP bearer token to authenticate to the leader",
-    required=True,
-)
-@click.option(
-    "--hpke-private-key",
-    help="The private key used to decrypt shares from the leader and helper.",
-    required=True,
-)
-@click.option(
     "--date",
     help="Date at which the backfill will start, going backwards (YYYY-MM-DD)",
     required=True,
@@ -276,6 +267,9 @@ def store_data(results, bqclient, table_id):
     required=True,
 )
 def main(project, ad_table_id, report_table_id, auth_token, hpke_private_key, date, task_config_url, ad_config_url):
+    hpke_private_key = os.environ.get("HPKE_PRIVATE_KEY", "")
+    auth_token = os.environ.get("AUTH_TOKEN", "")
+
     global ads
     ad_table_id = project + "." + ad_table_id
     report_table_id = project + "." + report_table_id

--- a/jobs/dap-collector-ppa-prod/dap_collector_ppa_prod/main.py
+++ b/jobs/dap-collector-ppa-prod/dap_collector_ppa_prod/main.py
@@ -266,7 +266,7 @@ def store_data(results, bqclient, table_id):
     help="URL where a JSON definition of the ads to task map can be found.",
     required=True,
 )
-def main(project, ad_table_id, report_table_id, auth_token, hpke_private_key, date, task_config_url, ad_config_url):
+def main(project, ad_table_id, report_table_id, date, task_config_url, ad_config_url):
     hpke_private_key = os.environ.get("HPKE_PRIVATE_KEY", "")
     auth_token = os.environ.get("AUTH_TOKEN", "")
 

--- a/jobs/dap-collector-ppa-prod/dap_collector_ppa_prod/main.py
+++ b/jobs/dap-collector-ppa-prod/dap_collector_ppa_prod/main.py
@@ -2,7 +2,6 @@ import asyncio
 import click
 import datetime
 import math
-import os
 import time
 
 from google.cloud import bigquery
@@ -252,6 +251,18 @@ def store_data(results, bqclient, table_id):
     required=True,
 )
 @click.option(
+    "--auth-token",
+    envvar='AUTH_TOKEN',
+    help="HTTP bearer token to authenticate to the leader",
+    required=True,
+)
+@click.option(
+    "--hpke-private-key",
+    envvar='HPKE_PRIVATE_KEY',
+    help="The private key used to decrypt shares from the leader and helper.",
+    required=True,
+)
+@click.option(
     "--date",
     help="Date at which the backfill will start, going backwards (YYYY-MM-DD)",
     required=True,
@@ -266,10 +277,7 @@ def store_data(results, bqclient, table_id):
     help="URL where a JSON definition of the ads to task map can be found.",
     required=True,
 )
-def main(project, ad_table_id, report_table_id, date, task_config_url, ad_config_url):
-    hpke_private_key = os.environ.get("HPKE_PRIVATE_KEY", "")
-    auth_token = os.environ.get("AUTH_TOKEN", "")
-
+def main(project, ad_table_id, report_table_id, auth_token, hpke_private_key, date, task_config_url, ad_config_url):
     global ads
     ad_table_id = project + "." + ad_table_id
     report_table_id = project + "." + report_table_id


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/AE-364

### problem
In the related airflow review, it was pointed out that we should handle the credentials differently there so that they aren't exposed in UIs. That switch shifts them from being ENV vars on the airflow job to be stored in google secrets manager.

From there, those secrets are passed to this job as environment variables rather than arguments.

### solution
compared to the xmatters setup to confirm my understanding
adjusted the hpke config and auth token to be read from os.environ instead. if these are missing then the requests to read from the collector will get error responses, which the job already captures
ran locally to confirm this adjustment
related airflow PR https://github.com/mozilla/telemetry-airflow/pull/2034

- handle secrets differently
- removed secret params from main method signature

Checklist for reviewer:

- [X] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [X] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [X] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
