### PR TITLE
feat(fxci): add an implicit 'submission_date' field to all records

### DIFF
--- a/jobs/fxci-taskcluster-export/fxci_etl/loaders/bigquery.py
+++ b/jobs/fxci-taskcluster-export/fxci_etl/loaders/bigquery.py
@@ -1,9 +1,9 @@
-from abc import ABC, abstractmethod
 import base64
+import json
+from abc import ABC, abstractmethod
 from collections import defaultdict
 from dataclasses import InitVar, asdict, dataclass
-import json
-import os
+from datetime import datetime, timezone
 from pprint import pprint
 from typing import Any
 
@@ -17,6 +17,7 @@ from fxci_etl.config import Config
 
 @dataclass
 class Record(ABC):
+    submission_date: str
     table_name: InitVar[str]
 
     def __post_init__(self, table_name):
@@ -24,6 +25,8 @@ class Record(ABC):
 
     @classmethod
     def from_dict(cls, table_name: str, data: dict[str, Any]) -> "Record":
+        current_date = datetime.now(timezone.utc).date()
+        data["submission_date"] = current_date.strftime("%Y-%m-%d")
         data["table_name"] = table_name
         return dacite.from_dict(data_class=cls, data=data)
 


### PR DESCRIPTION
We need a date field to use for partitioning. Apparently the standard name for this is 'submission_date'. So add this to all records across all tables.

Bug: 1904928

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
