### PR TITLE
fix(fxci): Make the pulse and monitoring configs optional

### DIFF
--- a/jobs/fxci-taskcluster-export/fxci_etl/config.py
+++ b/jobs/fxci-taskcluster-export/fxci_etl/config.py
@@ -68,10 +68,12 @@ class StorageConfig:
 
 @dataclass(frozen=True)
 class Config:
-    pulse: PulseConfig
     bigquery: BigQueryConfig
-    monitoring: MonitoringConfig
     storage: StorageConfig
+    # Depending on the commands being run, the pulse or monitoring
+    # configs may not be necessary.
+    pulse: Optional[PulseConfig]
+    monitoring: Optional[MonitoringConfig]
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "Config":


### PR DESCRIPTION
This way you don't need to define configuration for commands you aren't even going to use.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
