### PR TITLE
[dap collectors] fix incorrect value for timestamp field in results table

### DIFF
--- a/jobs/dap-collector-ppa-dev/dap_collector_ppa_dev/main.py
+++ b/jobs/dap-collector-ppa-dev/dap_collector_ppa_dev/main.py
@@ -169,8 +169,9 @@ def build_error_result(task_id, timestamp, metric_type, error):
     results = {}
     results["counts"] = []
     results["reports"] = []
+    slot_start = int(timestamp.timestamp())
 
-    rpt = build_base_report(task_id, timestamp, metric_type, collection_time)
+    rpt = build_base_report(task_id, slot_start, metric_type, collection_time)
     rpt["collection_duration"] = 0
     rpt["error"] = error
 

--- a/jobs/dap-collector-ppa-prod/dap_collector_ppa_prod/main.py
+++ b/jobs/dap-collector-ppa-prod/dap_collector_ppa_prod/main.py
@@ -169,8 +169,9 @@ def build_error_result(task_id, timestamp, metric_type, error):
     results = {}
     results["counts"] = []
     results["reports"] = []
+    slot_start = int(timestamp.timestamp())
 
-    rpt = build_base_report(task_id, timestamp, metric_type, collection_time)
+    rpt = build_base_report(task_id, slot_start, metric_type, collection_time)
     rpt["collection_duration"] = 0
     rpt["error"] = error
 
@@ -241,13 +242,12 @@ def check_time_precision(time_precision_minutes, end_collection_date):
         if MINUTES_IN_DAY % time_precision_minutes > 0:
             # time precision has to evenly divide a day in order for this collector code to query all aggregations
             return f"Task has time precision that does not evenly divide a day"
-    else:
-        if time_precision_minutes % MINUTES_IN_DAY != 0:
-            # time precision is a day or longer, but is not a multiple of a day
-            return f"Task has time precision that is not an even multiple of a day"
-        elif end_collection_date_seconds % (time_precision_minutes*60) != 0:
-            # time precision is a multiple of day, but the end does not align with this task's buckets
-            return f"{end_collection_date} does not align with task aggregation buckets"
+    elif time_precision_minutes % MINUTES_IN_DAY != 0:
+        # time precision is a day or longer, but is not a multiple of a day
+        return f"Task has time precision that is not an even multiple of a day"
+    elif end_collection_date_seconds % (time_precision_minutes*60) != 0:
+        # time precision is a multiple of day, but the end does not align with this task's buckets
+        return f"{end_collection_date} does not align with task aggregation buckets"
 
     return None
 


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/AE-457

### problem
My testing on the error cases was done without cloud auth so I didn't validate the writes to bigquery succeeded. The code didn't enforce any type constraints so I had passed the wrong kind of value to one of the method parameters.

The docker builds were updated and then the dev job ran but failed due to the error `TypeError: Object of type datetime is not JSON serializable`.

This run was expected to get an error record written to bigquery and not an airflow error since the airflow schedule hasn't switched to only pass in dates at midnight yet.

### solution
I reproduced this locally using the same parameters that the airflow job ran with, and then figured out that the base report expected an int for the slot_start field.

### testing
```
python3 main.py --date=2024-07-16T15:15:00+00:00 --project=moz-fx-ads-nonprod --ad-table-id=ppa_dev.measurements --report-table-id=ppa_dev.reports --task-config-url=https://storage.googleapis.com/ads-nonprod-stage-ppa-dev/tasks.json --ad-config-url=https://storage.googleapis.com/ads-nonprod-stage-ppa-dev/ads.json
```
ran this before and after the code adjustment. before the change it had the `not JSON serializable` error, after it succeeded and I confirmed the report result with the error message showed up in bigquery.


Checklist for reviewer:

- [X] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [X] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [X] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
