### PR TITLE
Use original report text for bugbug classification when translation is missing

### DIFF
--- a/jobs/broken-site-report-ml/broken_site_report_ml/main.py
+++ b/jobs/broken-site-report-ml/broken_site_report_ml/main.py
@@ -331,7 +331,11 @@ def main(bq_project_id, bq_dataset_id):
                 row["uuid"]: {
                     "uuid": row["uuid"],
                     "title": row["title"],
-                    "body": row.get("translated_text", row["body"]),
+                    "body": (
+                        row["translated_text"]
+                        if row.get("translated_text")
+                        else row["body"]
+                    ),
                 }
                 for row in chunk
             }


### PR DESCRIPTION
There [are some failing runs](https://workflow.telemetry.mozilla.org/log?execution_date=2024-07-28T22%3A45%3A00%2B00%3A00&task_id=broken_site_report_ml&dag_id=broken_site_report_ml&map_index=-1) that happened when an empty report text was sent to bugbug. It appears that on a rare occasion the report text is not translated (someone submitted huge log from console, for example). So in such case, we can use the original report text for ml classification.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
