### PR TITLE
Add bugzilla token as an env variable as a default option for argparse for webcompat-kb job

### DIFF
--- a/jobs/webcompat-kb/webcompat_kb/main.py
+++ b/jobs/webcompat-kb/webcompat_kb/main.py
@@ -1,6 +1,7 @@
 import argparse
 import google.auth
 import logging
+import os
 import requests
 import re
 import time
@@ -1211,7 +1212,11 @@ def get_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--bq_project_id", required=True, help="BigQuery project id")
     parser.add_argument("--bq_dataset_id", required=True, help="BigQuery dataset id")
-    parser.add_argument("--bugzilla_api_key", help="Bugzilla API key")
+    parser.add_argument(
+        "--bugzilla_api_key",
+        help="Bugzilla API key",
+        default=os.environ.get("BUGZILLA_API_KEY"),
+    )
     return parser
 
 


### PR DESCRIPTION
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
