### PR TITLE
Detect and correct wraparound for negative PPA conversion counts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,9 @@ jobs:
       - run:
           name: Build Docker image
           command: docker build -t app:build jobs/dap-collector-ppa-dev/
+      - run:
+          name: Test Code
+          command: docker run app:build python3 -m pytest
 
   build-job-dap-collector-ppa-prod:
     docker:
@@ -148,6 +151,9 @@ jobs:
       - run:
           name: Build Docker image
           command: docker build -t app:build jobs/dap-collector-ppa-prod/
+      - run:
+          name: Test Code
+          command: docker run app:build python3 -m pytest
 
   build-job-desktop-mobile-mau-2020:
     docker:

--- a/jobs/dap-collector-ppa-dev/ci_job.yaml
+++ b/jobs/dap-collector-ppa-dev/ci_job.yaml
@@ -10,3 +10,6 @@ build-job-dap-collector-ppa-dev:
     - run:
         name: Build Docker image
         command: docker build -t app:build jobs/dap-collector-ppa-dev/
+    - run:
+        name: Test Code
+        command: docker run app:build python3 -m pytest

--- a/jobs/dap-collector-ppa-dev/dap_collector_ppa_dev/main.py
+++ b/jobs/dap-collector-ppa-dev/dap_collector_ppa_dev/main.py
@@ -106,7 +106,7 @@ async def collect_once(task, timestamp, duration, hpke_private_key, auth_token):
         stderr = stderr.decode()
     except asyncio.exceptions.TimeoutError:
         rpt["collection_duration"] = time.perf_counter() - start_counter
-        rpt["error"] = f"TIMEOUT"
+        rpt["error"] = "TIMEOUT"
 
         res["reports"].append(rpt)
         return res
@@ -126,11 +126,11 @@ async def collect_once(task, timestamp, duration, hpke_private_key, auth_token):
     else:
         for line in stdout.splitlines():
             if line.startswith("Aggregation result:"):
-                entries = parse_histogram(line[21:-1])
+                entries = parse_vector(line[21:-1])
 
                 rpt["value"] = entries
 
-                for i in range(5):
+                for i, entry in enumerate(entries):
                     ad = get_ad(task["task_id"], i)
                     print(task["task_id"], i, ad)
                     if ad is not None:
@@ -145,7 +145,7 @@ async def collect_once(task, timestamp, duration, hpke_private_key, auth_token):
                         cnt["task_index"] = i
                         cnt["task_size"] = task["task_size"]
                         cnt["campaign_id"] = ad["advertiserInfo"]["campaignId"]
-                        cnt["conversion_count"] = entries[i]
+                        cnt["conversion_count"] = entry
 
                         res["counts"].append(cnt)
             elif line.startswith("Number of reports:"):
@@ -165,7 +165,7 @@ async def collect_once(task, timestamp, duration, hpke_private_key, auth_token):
     return res
 
 
-def parse_histogram(histogram_str):
+def parse_vector(histogram_str):
     count_strs = histogram_str.split(",")
     return [
         correct_wraparound(int(count_str))
@@ -346,11 +346,13 @@ def store_data(results, bqclient, table_id):
 )
 @click.option(
     "--auth-token",
+    envvar='AUTH_TOKEN',
     help="HTTP bearer token to authenticate to the leader",
     required=True,
 )
 @click.option(
     "--hpke-private-key",
+    envvar='HPKE_PRIVATE_KEY',
     help="The private key used to decrypt shares from the leader and helper.",
     required=True,
 )

--- a/jobs/dap-collector-ppa-dev/tests/test_main.py
+++ b/jobs/dap-collector-ppa-dev/tests/test_main.py
@@ -1,0 +1,6 @@
+from dap_collector_ppa_dev.main import parse_vector
+
+
+def test_parse_vector():
+    ret = parse_vector("54, 49, 340282366920938462946865773367900766208, 340282366920938462946865773367900766206, 1")
+    assert ret == [54, 49, -1, -3, 1]

--- a/jobs/dap-collector-ppa-prod/ci_job.yaml
+++ b/jobs/dap-collector-ppa-prod/ci_job.yaml
@@ -10,3 +10,6 @@ build-job-dap-collector-ppa-prod:
     - run:
         name: Build Docker image
         command: docker build -t app:build jobs/dap-collector-ppa-prod/
+    - run:
+        name: Test Code
+        command: docker run app:build python3 -m pytest

--- a/jobs/dap-collector-ppa-prod/tests/test_main.py
+++ b/jobs/dap-collector-ppa-prod/tests/test_main.py
@@ -1,0 +1,6 @@
+from dap_collector_ppa_prod.main import parse_vector
+
+
+def test_parse_vector():
+    ret = parse_vector("54, 49, 340282366920938462946865773367900766208, 340282366920938462946865773367900766206, 1")
+    assert ret == [54, 49, -1, -3, 1]


### PR DESCRIPTION
Differential privacy in [Prio][1] can result in negative conversion counts, which then wrap around to large numbers as all operations are performed modulo a large prime number.

This change hard-codes the prime number used for the Prio3SumVec data type (currently the only data type we use for DAP reports) to detect and correct this behavior, such that we can generate human-friendly reports for advertisers.

Namely, given the modulus P is a 128-bit prime, any value N in the histogram that is greater than 2^127 is replaced with (N-P).

JIRA: [AE-553][2]

[1]: https://github.com/divviup/libprio-rs/
[2]: https://mozilla-hub.atlassian.net/browse/AE-553

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
