### PR TITLE
Don't add dependencies of webcompat:platform-bug bugs

### DIFF
--- a/jobs/webcompat-kb/tests/test_main.py
+++ b/jobs/webcompat-kb/tests/test_main.py
@@ -1428,7 +1428,7 @@ def test_kb_bugs_from_platform_bugs(bz):
                 "see_also": [],
                 "severity": "S3",
                 "product": "Core",
-                "depends_on": [999999],
+                "depends_on": [],
                 "summary": "Example core site report and platform bug",
                 "resolution": "",
                 "last_change_time": "2024-05-27T15:07:03Z",

--- a/jobs/webcompat-kb/tests/test_main.py
+++ b/jobs/webcompat-kb/tests/test_main.py
@@ -1389,8 +1389,8 @@ def test_values_with_colon():
     assert parse_string_to_json(input_str) == expected
 
 
-def test_filter_kb_other(bz):
-    core_as_kb_bugs = bz.filter_kb_other(
+def test_kb_bugs_from_platform_bugs(bz):
+    core_as_kb_bugs = bz.kb_bugs_from_platform_bugs(
         SAMPLE_CORE_AS_KB_BUGS, {1835339}, {1896383, 222222}
     )
 

--- a/jobs/webcompat-kb/webcompat_kb/main.py
+++ b/jobs/webcompat-kb/webcompat_kb/main.py
@@ -306,6 +306,10 @@ class BugzillaToBigQuery:
                 for blocked_id in bug["blocks"]
                 if blocked_id in site_report_ids
             ]
+
+            # Don't store bugs that platform bug depends on
+            bug["depends_on"] = []
+
             filtered[bug_id] = bug
 
         return filtered

--- a/jobs/webcompat-kb/webcompat_kb/main.py
+++ b/jobs/webcompat-kb/webcompat_kb/main.py
@@ -79,11 +79,11 @@ FILTER_CONFIG = {
         "o2": "substring",
         "v2": "webcompat:site-report",
     },
-    "knowledge_base_wc": {
+    "knowledge_base": {
         "product": "Web Compatibility",
         "component": "Knowledge Base",
     },
-    "knowledge_base_other": {
+    "platform_bugs": {
         "f1": "product",
         "o1": "notequals",
         "v1": "Web Compatibility",
@@ -169,7 +169,7 @@ RELATION_CONFIG = {
 }
 
 LINK_FIELDS = ["other_browser_issues", "standards_issues", "standards_positions"]
-CORE_RELATION_CONFIG = {key: RELATION_CONFIG[key] for key in LINK_FIELDS}
+PLATFORM_RELATION_CONFIG = {key: RELATION_CONFIG[key] for key in LINK_FIELDS}
 
 
 def extract_int_from_field(field: str) -> Optional[int]:
@@ -280,20 +280,25 @@ class BugzillaToBigQuery:
 
         return fetch_completed, data
 
-    def filter_kb_other(
+    def kb_bugs_from_platform_bugs(
         self,
-        kb_bugs_other: BugsById,
-        compat_kb_ids: set[int],
+        platform_bugs: BugsById,
+        kb_ids: set[int],
         site_report_ids: set[int],
     ) -> BugsById:
+        """Get a list of platform bugs that should also be considered knowledge base bugs
+
+        These are platform bugs that aren't blocking an existing kb entry
+        """
+
         filtered = {}
 
-        for bug_id, source_bug in kb_bugs_other.items():
-            bug = {**source_bug}
-
-            # Check if the core bug already has a kb entry and skip if so
-            if any(blocked_id in compat_kb_ids for blocked_id in bug["blocks"]):
+        for bug_id, source_bug in platform_bugs.items():
+            # Check if the platform bug already has a kb entry and skip if so
+            if any(blocked_id in kb_ids for blocked_id in source_bug["blocks"]):
                 continue
+
+            bug = source_bug.copy()
 
             # Only store a breakage bug as it's the relation we care about
             bug["blocks"] = [
@@ -344,26 +349,25 @@ class BugzillaToBigQuery:
         site_reports = fetched_bugs["site_reports_wc"]
         site_reports.update(fetched_bugs["site_reports_other"])
 
-        kb_bugs = fetched_bugs["knowledge_base_wc"]
-        kb_bugs.update(
-            self.filter_kb_other(
-                fetched_bugs["knowledge_base_other"],
-                set(kb_bugs.keys()),
-                set(site_reports.keys()),
-            )
-        )
+        kb_bugs = fetched_bugs["knowledge_base"]
 
         kb_depends_on_ids = set()
         for bug in kb_bugs.values():
             kb_depends_on_ids |= set(bug["depends_on"])
 
-        logging.info("Fetching blocking bugs for KB bugs")
+        platform_bugs = fetched_bugs["platform_bugs"]
+        kb_bugs.update(self.kb_bugs_from_platform_bugs(platform_bugs,
+                                                       set(kb_bugs.keys()),
+                                                       set(site_reports.keys())))
 
-        completed, core_bugs = self.fetch_blocking_bugs(kb_depends_on_ids)
+        logging.info("Fetching blocking bugs for KB bugs")
+        completed, extra_platform_bugs = self.fetch_blocking_bugs(kb_depends_on_ids)
 
         if not completed:
             logging.error("Failed to fetch blocking bugs")
             return None
+
+        platform_bugs.update(extra_platform_bugs)
 
         all_bugs: dict[int, Bug] = {}
         for bugs in [
@@ -372,11 +376,11 @@ class BugzillaToBigQuery:
             fetched_bugs["interventions"],
             fetched_bugs["other"],
             fetched_bugs["parity"],
-            core_bugs,
+            platform_bugs,
         ]:
             all_bugs.update(bugs)
 
-        return all_bugs, site_reports, kb_bugs, core_bugs
+        return all_bugs, site_reports, kb_bugs, platform_bugs
 
     def process_relations(
         self, bugs: BugsById, relation_config: Mapping[str, Mapping[str, Any]]
@@ -1152,7 +1156,7 @@ class BugzillaToBigQuery:
                 "Fetching bugs from Bugzilla was not completed due to an error, aborting."
             )
 
-        all_bugs, site_reports, kb_bugs, core_bugs = fetch_all_result
+        all_bugs, site_reports, kb_bugs, platform_bugs = fetch_all_result
 
         # Process KB bugs fields and get their dependant core/breakage bugs ids.
         kb_data, kb_dep_ids = self.process_relations(kb_bugs, RELATION_CONFIG)
@@ -1166,12 +1170,12 @@ class BugzillaToBigQuery:
 
         missing_bugs, core_missing = fetch_missing_result
 
-        core_bugs.update(core_missing)
+        platform_bugs.update(core_missing)
         all_bugs.update(missing_bugs)
 
         # Process core bugs and update KB data with missing links from core bugs.
-        if core_bugs:
-            core_data, _ = self.process_relations(core_bugs, CORE_RELATION_CONFIG)
+        if platform_bugs:
+            core_data, _ = self.process_relations(platform_bugs, PLATFORM_RELATION_CONFIG)
             kb_data = self.add_links(kb_data, core_data)
 
         # Build relations for BQ tables.


### PR DESCRIPTION
Generally for knowledge base entries we want to take one level of deps, corresponding to the actual platform bugs. But for platform bugs themselves we don't need to add a second level of dependencies.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
