### PR TITLE
Move webcompat to using pyproject and add a test script

### DIFF
--- a/jobs/webcompat-kb/README.md
+++ b/jobs/webcompat-kb/README.md
@@ -15,14 +15,16 @@ docker build -t webcompat-kb .
 To run locally, first install dependencies in `jobs/webcompat-kb`:
 
 ```sh
-pip install -r requirements.txt
+python3 -m venv  _venv
+source _venv/bin/activate
+pip install -e .
 ```
 
-And then run the script after authentication with gcloud: 
+And then run the script after authentication with gcloud:
 
 ```sh
 gcloud auth application-default login
-python3 webcompat_kb/main.py --bq_project_id=<your_project_id> --bq_dataset_id=<your_dataset_id>
+webcompat-etl --bq-project=<your_project_id> --no-write
 ```
 
 ## Development

--- a/jobs/webcompat-kb/README.md
+++ b/jobs/webcompat-kb/README.md
@@ -32,18 +32,10 @@ webcompat-etl --bq-project=<your_project_id> --no-write
 Run tests with:
 
 ```sh
-pytest
+./test.sh
 ```
 
-`flake8` and `black` are included for code linting and formatting:
-
+Ruff is used for code formatting:
 ```sh
-pytest --black --flake8
-```
-
-or
-
-```sh
-flake8 webcompat_kb/ tests/
-black --diff webcompat_kb/ tests/
+ruff format .
 ```

--- a/jobs/webcompat-kb/pyproject.toml
+++ b/jobs/webcompat-kb/pyproject.toml
@@ -1,0 +1,43 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "webcompat-kb"
+description = "Download log files from Taskcluster CI systems"
+authors = [
+  {name = "Mozilla Corporation"}
+]
+version = "0.1.0"
+classifiers = [
+    "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+]
+dependencies = [
+  "google-cloud-bigquery==3.24.0",
+]
+
+[project.optional-dependencies]
+test = [
+  "mypy==1.10.0",
+  "pandas-stubs==2.2.2.240603",
+  "pytest-ruff==0.3.2",
+  "pytest==8.2.2",
+  "ruff==0.4.8",
+  "types-cachetools==5.3.0.7",
+  "types-cffi==1.16.0.20240331",
+  "types-protobuf==5.27.0.20240626",
+  "types-pyOpenSSL==24.1.0.20240425",
+  "types-python-dateutil==2.9.0.20240316",
+  "types-pytz==2024.1.0.20240417",
+  "types-requests==2.32.0.20240712",
+  "types-setuptools==70.3.0.20240710",
+  "types-tqdm==4.66.0.20240417",
+]
+
+[project.scripts]
+webcompat-etl = "webcompat_kb.main:main"
+
+[tool.pytest]
+testpaths = ["tests"]

--- a/jobs/webcompat-kb/setup.py
+++ b/jobs/webcompat-kb/setup.py
@@ -1,15 +1,5 @@
 #!/usr/bin/env python
 
-from setuptools import setup, find_packages
+import setuptools
 
-readme = open("README.md").read()
-
-setup(
-    name="webcompat-kb",
-    version="0.1.0",
-    author="Mozilla Corporation",
-    packages=find_packages(include=["webcompat_kb"]),
-    long_description=readme,
-    include_package_data=True,
-    license="MPL 2.0",
-)
+setuptools.setup()

--- a/jobs/webcompat-kb/test.sh
+++ b/jobs/webcompat-kb/test.sh
@@ -1,0 +1,15 @@
+#! /usr/bin/bash
+
+set -ex
+
+if [ ! -d "_venv" ]; then
+  python3 -m _venv
+fi
+source _venv/bin/activate
+
+pip install -e .
+pip install .[test]
+
+mypy -m webcompat_kb
+pytest --ruff --ruff-format .
+

--- a/jobs/webcompat-kb/webcompat_kb/__init__.py
+++ b/jobs/webcompat-kb/webcompat_kb/__init__.py
@@ -1,0 +1,3 @@
+from . import main
+
+__all__ = ["main"]

--- a/jobs/webcompat-kb/webcompat_kb/main.py
+++ b/jobs/webcompat-kb/webcompat_kb/main.py
@@ -328,7 +328,7 @@ class BugzillaToBigQuery:
             if any(blocked_id in kb_ids for blocked_id in source_bug["blocks"]):
                 continue
 
-            bug = source_bug.copy()
+            bug = {**source_bug}
 
             # Only store a breakage bug as it's the relation we care about
             bug["blocks"] = [
@@ -355,7 +355,7 @@ class BugzillaToBigQuery:
         filtered = {}
 
         for bug_id, source_bug in etp_reports.items():
-            bug = source_bug.copy()
+            bug = {**source_bug}
 
             blocks = [
                 blocked_id
@@ -1306,7 +1306,7 @@ class BugzillaToBigQuery:
             logging.info("Not updating bug history")
             history_changes = []
 
-        etp_rels = {}
+        etp_rels: Mapping[str, list[Mapping[str, Any]]] = {}
         if etp_reports:
             etp_reports_unified = self.unify_etp_dependencies(
                 etp_reports, etp_dependencies


### PR DESCRIPTION
This adds a `test.sh` script for running the tests without docker, and a `webcompat-etl` script to run locally.

`requirements.txt` isn't removed in order to avoid needing to also change the Docker image.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
