### PR TITLE
Switch to dev mode before deleting Looker branches

### DIFF
--- a/jobs/looker-utils/looker_utils/main.py
+++ b/jobs/looker-utils/looker_utils/main.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 import click
 import looker_sdk
 from looker_sdk import methods40 as methods
+from looker_sdk.sdk.api40 import models
 
 
 def setup_sdk(client_id, client_secret, instance) -> methods.Looker40SDK:
@@ -70,7 +71,7 @@ def delete_branches(ctx, project, inactive_days, exclude):
     )
 
     # switch to dev mode
-    sdk.update_session({"workspace_id":"dev"})
+    sdk.update_session(models.WriteApiSession(workspace_id="dev"))
 
     for lookml_project in project:
         branches = sdk.all_git_branches(project_id=lookml_project)

--- a/jobs/looker-utils/looker_utils/main.py
+++ b/jobs/looker-utils/looker_utils/main.py
@@ -69,6 +69,9 @@ def delete_branches(ctx, project, inactive_days, exclude):
         days=inactive_days
     )
 
+    # switch to dev mode
+    sdk.update_session({"workspace_id":"dev"})
+
     for lookml_project in project:
         branches = sdk.all_git_branches(project_id=lookml_project)
 
@@ -83,6 +86,7 @@ def delete_branches(ctx, project, inactive_days, exclude):
                 print(
                     f"{branch.name} in {lookml_project}, last commit on {commit_date}"
                 )
+                
                 sdk.delete_git_branch(
                     project_id=lookml_project, branch_name=branch.name
                 )


### PR DESCRIPTION
The Airflow task is currently failing as branches can only be deleted in dev mode https://workflow.telemetry.mozilla.org/dags/looker/grid?dag_run_id=manual__2025-01-02T17%3A23%3A41.422064%2B00%3A00&task_id=delete_outdated_branches&tab=logs

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
