### PR TITLE
fix(code):[Workday/NetSuite integration] Add logger to international transfer report return

### DIFF
--- a/jobs/eam-integrations/scripts/workday_netsuite/api/workday/workday.py
+++ b/jobs/eam-integrations/scripts/workday_netsuite/api/workday/workday.py
@@ -114,6 +114,7 @@ class WorkDayRaaService():
         result = requests.get(link.format(end_date=end_date, begin_date=begin_date),
                               auth=(self.config['username'],
                                     self.config['password']),
-                              timeout=self.config['timeout'])
-        
+                              timeout=self.config['timeout'])        
+        self.logger.info('WorkDay response: %s', result.text)
+        self.logger.info('link: %s', link.format(end_date=end_date, begin_date=begin_date))
         return json.loads(result.text)


### PR DESCRIPTION
## Description
Add a logger to the international transfer report result.
Reason: trying to understand why we are getting this error in the international transfer func.
ERROR: Extra data: line 1 column 5 (char 4)

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
[ASP-6073](https://mozilla-hub.atlassian.net/browse/ASP-6073)
 
 


[ASP-6006]: https://mozilla-hub.atlassian.net/browse/ASP-6006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ