### PR TITLE
Store task tags in a separate table

### DIFF
--- a/jobs/fxci-taskcluster-export/.gitignore
+++ b/jobs/fxci-taskcluster-export/.gitignore
@@ -1,1 +1,2 @@
 build
+config.dev.toml

--- a/jobs/fxci-taskcluster-export/fxci_etl/schemas.py
+++ b/jobs/fxci-taskcluster-export/fxci_etl/schemas.py
@@ -82,9 +82,18 @@ class Runs(Record):
 
 
 @dataclass
-class Tag:
-    key: BigQueryTypes.STRING
-    value: BigQueryTypes.STRING
+class Tags:
+    created_for_user: Optional[BigQueryTypes.STRING]
+    kind: Optional[BigQueryTypes.STRING]
+    label: Optional[BigQueryTypes.STRING]
+    os: Optional[BigQueryTypes.STRING]
+    owned_by: Optional[BigQueryTypes.STRING]
+    project: Optional[BigQueryTypes.STRING]
+    trust_domain: Optional[BigQueryTypes.STRING]
+    worker_implementation: Optional[BigQueryTypes.STRING]
+    # No longer used. Kept for backwards compatibility with older records.
+    key: Optional[BigQueryTypes.STRING]
+    value: Optional[BigQueryTypes.STRING]
 
 
 @dataclass
@@ -93,7 +102,7 @@ class Tasks(Record):
     task_group_id: BigQueryTypes.STRING
     task_id: BigQueryTypes.STRING
     task_queue_id: BigQueryTypes.STRING
-    tags: list[Tag]
+    tags: Tags
 
     def __str__(self):
         return self.task_id

--- a/jobs/fxci-taskcluster-export/fxci_etl/schemas.py
+++ b/jobs/fxci-taskcluster-export/fxci_etl/schemas.py
@@ -29,13 +29,14 @@ def generate_schema(cls):
         if origin is Union and type(None) in args:
             mode = "NULLABLE"
             _type = [arg for arg in args if arg is not type(None)][0]
-
-        elif origin is list:
-            mode = "REPEATED"
-            _type = args[0]
-
+            origin = get_origin(_type)
+            args = get_args(_type)
         else:
             mode = "REQUIRED"
+
+        if origin is list:
+            mode = "REPEATED"
+            _type = args[0]
 
         if is_dataclass(_type):
             nested_schema = generate_schema(_type)

--- a/jobs/fxci-taskcluster-export/test/test_pulse_handler.py
+++ b/jobs/fxci-taskcluster-export/test/test_pulse_handler.py
@@ -1,0 +1,72 @@
+from dataclasses import asdict
+from typing import Any
+import pytest
+
+from fxci_etl.pulse.handler import BigQueryHandler, Event
+
+
+@pytest.fixture
+def run_bigquery(make_config):
+    config = make_config()
+
+    def inner(data: dict[str, Any]):
+        event = Event.from_dict({"data": data})
+        bq = BigQueryHandler(config)
+        bq.process_event(event)
+        return bq
+
+    return inner
+
+
+@pytest.fixture
+def event():
+    task_id = "abc"
+    return {
+        "runId": 0,
+        "status": {
+            "runs": [
+                {
+                    "reasonCreated": "just because",
+                    "reasonResolved": "it finished",
+                    "resolved": 1,
+                    "scheduled": 2,
+                    "state": "completed",
+                },
+            ],
+            "schedulerId": "scheduler",
+            "taskId": task_id,
+            "taskGroupId": "group",
+            "taskQueueId": "queue",
+        },
+        "task": {
+            "tags": {
+                "createdForUser": "user",
+                "owned by": "user",
+                "trust_domain": "domain",
+                "worker-implementation": "worker",
+            }
+        }
+    }
+
+
+def test_big_query_handler_no_run_id(run_bigquery):
+    bq = run_bigquery({})
+    assert bq.task_records == []
+    assert bq.run_records == []
+
+
+def test_big_query_handler_run_0(run_bigquery, event):
+    bq = run_bigquery(event)
+    assert len(bq.task_records) == 1
+    assert len(bq.run_records) == 1
+    
+    tags = [t for t, v in asdict(bq.task_records[0])["tags"].items() if v is not None]
+    assert len(event["task"]["tags"]) == len(tags)
+
+
+def test_big_query_handler_run_1(run_bigquery, event):
+    event["runId"] = 1
+    event["status"]["runs"].append(event["status"]["runs"][0].copy())
+    bq = run_bigquery(event)
+    assert len(bq.task_records) == 0
+    assert len(bq.run_records) == 1


### PR DESCRIPTION
The motivation for this is to make it easier to write queries / create dashboards that filter by more than one tag at a time. Having them as a nested column makes this difficult!

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
