### PR TITLE
fix(fxci): bump version in tasks table

### DIFF
--- a/jobs/fxci-taskcluster-export/fxci_etl/config.py
+++ b/jobs/fxci-taskcluster-export/fxci_etl/config.py
@@ -39,7 +39,7 @@ class PulseConfig:
 @dataclass(frozen=True)
 class BigQueryTableConfig:
     metrics: str = "worker_metrics_v1"
-    tasks: str = "tasks_v1"
+    tasks: str = "tasks_v2"
     runs: str = "task_runs_v1"
 
 

--- a/jobs/fxci-taskcluster-export/fxci_etl/pulse/handler.py
+++ b/jobs/fxci-taskcluster-export/fxci_etl/pulse/handler.py
@@ -94,7 +94,7 @@ class BigQueryHandler(PulseHandler):
         self.run_records: list[Record] = []
 
         self._convert_camel_case_re = re.compile(r"(?<!^)(?=[A-Z])")
-        self._known_tags = set(Tags.__annotations__.keys()) - {"key", "value"}
+        self._known_tags = set(Tags.__annotations__.keys())
 
     def _normalize_tag(self, tag: str) -> str | None:
         """Tags are not well standardized and can be in camel case, snake case,

--- a/jobs/fxci-taskcluster-export/fxci_etl/schemas.py
+++ b/jobs/fxci-taskcluster-export/fxci_etl/schemas.py
@@ -91,9 +91,6 @@ class Tags:
     project: Optional[BigQueryTypes.STRING]
     trust_domain: Optional[BigQueryTypes.STRING]
     worker_implementation: Optional[BigQueryTypes.STRING]
-    # No longer used. Kept for backwards compatibility with older records.
-    key: Optional[BigQueryTypes.STRING]
-    value: Optional[BigQueryTypes.STRING]
 
 
 @dataclass


### PR DESCRIPTION
I wrongfully thought that the schema changes to the tasks table that I made were backwards compatible, but I missed that I was changing it from a REPEATED STRUCT column to just a STRUCT.

So let's create a new v2 table. I'll write a backfill task / script to repopulate the old data from the v1 table later.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
