### PR TITLE
Handle capitalization changes in keywords

### DIFF
--- a/jobs/webcompat-kb/webcompat_kb/metric_changes.py
+++ b/jobs/webcompat-kb/webcompat_kb/metric_changes.py
@@ -258,7 +258,17 @@ def bugs_historic_states(
                 if field_change.field_name == "keywords":
                     for keyword in field_change.added.split(", "):
                         if keyword:
-                            prev.keywords.remove(keyword)
+                            try:
+                                prev.keywords.remove(keyword)
+                            except ValueError:
+                                # Occasionally keywords change case
+                                for prev_keyword in prev.keywords:
+                                    if prev_keyword.lower() == keyword.lower():
+                                        prev.keywords.remove(prev_keyword)
+                                        logging.warning(f"Didn't find keyword {keyword} using {prev_keyword}")
+                                        break
+                                else:
+                                    raise
                     for keyword in field_change.removed.split(", "):
                         if keyword:
                             prev.keywords.append(keyword)


### PR DESCRIPTION
It seems sometimes keywords can change in their capitalization, so if we don't find the keyword in the historic set check for entries that differ only in case.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
