### PR TITLE
Refactor bugzilla import

### DIFF
--- a/jobs/webcompat-kb/webcompat_kb/metric_changes.py
+++ b/jobs/webcompat-kb/webcompat_kb/metric_changes.py
@@ -9,8 +9,8 @@ from typing import Iterator, Mapping, Optional, Sequence
 from google.cloud import bigquery
 
 from .base import EtlJob
-from .bugzilla import parse_string_to_json
 from .bqhelpers import ensure_table
+from .bugzilla import parse_user_story
 
 FIXED_STATES = {"RESOLVED", "VERIFIED"}
 
@@ -329,7 +329,7 @@ def compute_historic_scores(
                         "index": i,
                         "keywords": state.keywords,
                         "url": state.url,
-                        "user_story": parse_string_to_json(state.user_story),
+                        "user_story": parse_user_story(state.user_story),
                     }
                 )
 


### PR DESCRIPTION
The previous import was getting rather hard to understand, because it
was mixing IO with bug grouping logic in a way that made it difficult
to tell which bugs ended up in which groups.
    
In the new version, we simply load all the bugs that we are interested
in into a single large dict at the start. We then do all the grouping
and filtering we need in Python code, before finally writing all the
data to bigquery.
    
Unlike bugs themselves, bug history is a bit more complicated because we allow
incremental updates. This is currently grouped into a single class
that only covers history updating, but some additional work would be
required to make it match the pure input/processing/output flow that
we have for bugs themselves.
    
In addition this change tries to used defined types wherever possible,
and avoids using untyped dictionaries except at the edges. This makes
it much easier to catch a class of errors using mypy.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
