### PR TITLE
fix(code): Bump default max_limit to 100

### DIFF
--- a/jobs/eam-integrations/scripts/workday_netsuite_integration.py
+++ b/jobs/eam-integrations/scripts/workday_netsuite_integration.py
@@ -948,7 +948,7 @@ def main(__name__, WorkdayToNetsuiteIntegration):
         action="store",
         type=int,
         help="limit the number of changes",
-        default=50
+        default=100
     )
     args = None
     args = parser.parse_args()


### PR DESCRIPTION
Change max_limit from 50 to 100
The max_limit parameter limits the changes that the automation does per run.

[https://mozilla-hub.atlassian.net/browse/ASP-6575](https://mozilla-hub.atlassian.net/browse/ASP-6575)

