### PR TITLE
Create a bigquery wrapper and use it everywhere

### DIFF
--- a/jobs/webcompat-kb/tests/test_bugzilla.py
+++ b/jobs/webcompat-kb/tests/test_bugzilla.py
@@ -7,7 +7,7 @@ from typing import Any, Iterable, Mapping
 import pytest
 import bugdantic.bugzilla
 
-from webcompat_kb.base import get_client
+from webcompat_kb.bqhelpers import get_client, BigQuery
 from webcompat_kb.bugzilla import (
     Bug,
     BugHistoryChange,
@@ -1148,8 +1148,8 @@ KEYWORDS_AND_STATUS = to_history(
 
 
 @pytest.fixture(scope="module")
-@patch("webcompat_kb.base.google.auth.default")
-@patch("webcompat_kb.base.bigquery.Client")
+@patch("webcompat_kb.bqhelpers.google.auth.default")
+@patch("webcompat_kb.bqhelpers.bigquery.Client")
 def bq_client(mock_bq, mock_auth_default):
     mock_credentials = Mock()
     mock_project_id = "placeholder_id"
@@ -1157,12 +1157,12 @@ def bq_client(mock_bq, mock_auth_default):
     mock_bq.return_value = Mock()
 
     mock_bq.return_value = Mock()
-    get_client(mock_project_id)
+    return BigQuery(get_client(mock_project_id), "test_dataset", True)
 
 
 @pytest.fixture(scope="module")
 def history_updater(bq_client):
-    return BugHistoryUpdater(bq_client, "test", None)
+    return BugHistoryUpdater(bq_client, None)
 
 
 def test_extract_int_from_field():

--- a/jobs/webcompat-kb/webcompat_kb/base.py
+++ b/jobs/webcompat-kb/webcompat_kb/base.py
@@ -3,8 +3,7 @@ import re
 from abc import ABC, abstractmethod
 from typing import Any, MutableMapping
 
-import google.auth
-from google.cloud import bigquery
+from .bqhelpers import BigQuery
 
 # In the following we assume ascii-only characters for now. That's perhaps wrong,
 # but it covers everything we're currently using.
@@ -27,26 +26,15 @@ class EtlJob(ABC):
         ALL_JOBS[cls.name] = cls
 
     @classmethod
-    def add_arguments(cls, parser: argparse.ArgumentParser) -> None:
-        pass
+    def add_arguments(cls, parser: argparse.ArgumentParser) -> None: ...
 
     def set_default_args(
         self, parser: argparse.ArgumentParser, args: argparse.Namespace
-    ) -> None:
-        pass
+    ) -> None: ...
 
     @abstractmethod
-    def main(self, client: bigquery.Client, args: argparse.Namespace) -> None:
+    def default_dataset(self, args: argparse.Namespace) -> str: ...
+
+    @abstractmethod
+    def main(self, bq_client: BigQuery, args: argparse.Namespace) -> None:
         pass
-
-
-def get_client(bq_project_id: str) -> bigquery.Client:
-    credentials, _ = google.auth.default(
-        scopes=[
-            "https://www.googleapis.com/auth/cloud-platform",
-            "https://www.googleapis.com/auth/drive",
-            "https://www.googleapis.com/auth/bigquery",
-        ]
-    )
-
-    return bigquery.Client(credentials=credentials, project=bq_project_id)

--- a/jobs/webcompat-kb/webcompat_kb/bqhelpers.py
+++ b/jobs/webcompat-kb/webcompat_kb/bqhelpers.py
@@ -1,16 +1,143 @@
+import logging
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Optional, Sequence, cast
+
+import google.auth
 from google.cloud import bigquery
 
 
-def ensure_table(
-    client: bigquery.Client,
-    bq_dataset_id: str,
-    table_id: str,
-    schema: list[bigquery.SchemaField],
-    recreate: bool,
-) -> None:
-    table = bigquery.Table(
-        f"{client.project}.{bq_dataset_id}.{table_id}", schema=schema
+def get_client(bq_project_id: str) -> bigquery.Client:
+    credentials, _ = google.auth.default(
+        scopes=[
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/bigquery",
+        ]
     )
-    if recreate:
-        client.delete_table(table, not_found_ok=True)
-    client.create_table(table, exists_ok=True)
+
+    return bigquery.Client(credentials=credentials, project=bq_project_id)
+
+
+@dataclass
+class RangePartition:
+    field: str
+    start: int
+    end: int
+    interval: int = 1
+
+
+class BigQuery:
+    def __init__(self, client: bigquery.Client, default_dataset_id: str, write: bool):
+        self.client = client
+        self.default_dataset_id = default_dataset_id
+        self.write = write
+
+    def get_dataset(self, dataset_id: Optional[str]) -> str:
+        if dataset_id is None:
+            return self.default_dataset_id
+        return dataset_id
+
+    def get_table_id(
+        self, dataset_id: Optional[str], table: bigquery.Table | str
+    ) -> bigquery.Table | str:
+        if isinstance(table, bigquery.Table):
+            return table
+
+        if "." in table:
+            return table
+
+        dataset_id = self.get_dataset(dataset_id)
+        return f"{self.client.project}.{dataset_id}.{table}"
+
+    def ensure_table(
+        self,
+        table_id: str,
+        schema: Iterable[bigquery.SchemaField],
+        recreate: bool = False,
+        dataset_id: Optional[str] = None,
+        partition: Optional[RangePartition] = None,
+    ) -> bigquery.Table:
+        table = bigquery.Table(self.get_table_id(dataset_id, table_id), schema=schema)
+        if partition:
+            table.range_partitioning = bigquery.table.RangePartitioning(
+                bigquery.table.PartitionRange(
+                    partition.start, partition.end, partition.interval
+                ),
+                field=partition.field,
+            )
+
+        if self.write:
+            if recreate:
+                self.client.delete_table(table, not_found_ok=True)
+            self.client.create_table(table, exists_ok=True)
+        return table
+
+    def write_table(
+        self,
+        table: bigquery.Table | str,
+        schema: list[bigquery.SchemaField],
+        rows: Sequence[Mapping[str, Any]],
+        overwrite: bool,
+        dataset_id: Optional[str] = None,
+    ) -> None:
+        table = self.get_table_id(dataset_id, table)
+
+        job_config = bigquery.LoadJobConfig(
+            source_format=bigquery.SourceFormat.NEWLINE_DELIMITED_JSON,
+            schema=schema,
+            write_disposition="WRITE_APPEND" if not overwrite else "WRITE_TRUNCATE",
+        )
+
+        if self.write:
+            job = self.client.load_table_from_json(
+                cast(Iterable[dict[str, Any]], rows),
+                table,
+                job_config=job_config,
+            )
+            job.result()
+            logging.info(f"Wrote {len(rows)} records into {table}")
+        else:
+            logging.info(f"Skipping writes, would have written {len(rows)} to {table}")
+            for row in rows:
+                logging.debug(f"  {row}")
+
+    def insert_rows(
+        self,
+        table: str | bigquery.Table,
+        rows: Sequence[Mapping[str, Any]],
+        dataset_id: Optional[str] = None,
+    ) -> None:
+        table = self.get_table_id(dataset_id, table)
+
+        if self.write:
+            errors = self.client.insert_rows_json(table, rows)
+            if errors:
+                logging.error(errors)
+        else:
+            logging.info(f"Skipping writes, would have written {len(rows)} to {table}")
+            for row in rows:
+                logging.debug(f"  {row}")
+
+    def query(
+        self,
+        query: str,
+        dataset_id: Optional[str] = None,
+        parameters: Optional[Sequence[bigquery.query._AbstractQueryParameter]] = None,
+    ) -> bigquery.table.RowIterator:
+        """Run a query
+
+        Note that this can't prevent writes in the case that the SQL does writes"""
+
+        job_config = bigquery.QueryJobConfig(
+            default_dataset=f"{self.client.project}.{self.get_dataset(dataset_id)}"
+        )
+        if parameters is not None:
+            job_config.query_parameters = parameters
+
+        logging.debug(query)
+        return self.client.query(query, job_config=job_config).result()
+
+    def delete_table(
+        self, table: bigquery.Table | str, not_found_ok: bool = False
+    ) -> None:
+        return self.client.delete_table(table, not_found_ok=not_found_ok)

--- a/jobs/webcompat-kb/webcompat_kb/main.py
+++ b/jobs/webcompat-kb/webcompat_kb/main.py
@@ -4,7 +4,8 @@ import sys
 
 # These imports are required to populate ALL_JOBS
 from . import bugzilla, crux, metric, metric_changes  # noqa: F401
-from .base import ALL_JOBS, VALID_PROJECT_ID, VALID_DATASET_ID, get_client
+from .base import ALL_JOBS, VALID_PROJECT_ID, VALID_DATASET_ID
+from .bqhelpers import get_client, BigQuery
 
 
 def get_parser() -> argparse.ArgumentParser:
@@ -99,7 +100,9 @@ def main() -> None:
 
         for job_name, job in jobs.items():
             logging.info(f"Running job {job_name}")
-            job.main(client, args)
+            bq_client = BigQuery(client, job.default_dataset(args), args.write)
+
+            job.main(bq_client, args)
     except Exception:
         if args.pdb:
             import pdb

--- a/jobs/webcompat-kb/webcompat_kb/utils.py
+++ b/jobs/webcompat-kb/webcompat_kb/utils.py
@@ -2,7 +2,7 @@ import argparse
 import logging
 import sys
 
-from .base import get_client
+from .bqhelpers import BigQuery, get_client
 
 
 def get_parser_create_test_dataset() -> argparse.ArgumentParser:
@@ -58,12 +58,12 @@ def create_test_dataset() -> None:
     if res != "y":
         sys.exit(1)
 
-    client = get_client(args.bq_project_id)
+    client = BigQuery(get_client(args.bq_project_id), test_dataset_name, args.write)
 
     if not args.write:
         logging.info("Not writing; pass --write to commit changes")
     else:
-        client.create_dataset(test_dataset_name, exists_ok=True)
+        client.client.create_dataset(test_dataset_name, exists_ok=True)
 
     for table_name in tables:
         target = f"{test_dataset_name}.{table_name}"
@@ -79,6 +79,6 @@ CLONE {src}
 """
         if args.write:
             logging.info(f"Creating table {target} from {src}")
-            client.query_and_wait(query)
+            client.query(query)
         else:
             logging.info(f"Would run query:{query}")


### PR DESCRIPTION
This centalises a lot of our common patterns in one place.

Each job gets a wrapper with the dataset approproately configured for the job. The wrapper also knows about the write flag, which it can use to avoid writes when creating tables or loading data, which is the common case, but it isn't able to prevent general queries from performing inserts.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
