### PR TITLE
Some more cleanup and smaller fixes for the WebCompat ETL

### DIFF
--- a/jobs/webcompat-kb/pyproject.toml
+++ b/jobs/webcompat-kb/pyproject.toml
@@ -41,6 +41,8 @@ test = [
 [project.scripts]
 webcompat-etl = "webcompat_kb.main:main"
 webcompat-create-test-dataset = "webcompat_kb.utils:create_test_dataset"
+webcompat-backfill-history = "webcompat_kb.utils:backfill_history"
+
 
 [tool.pytest]
 testpaths = ["tests"]

--- a/jobs/webcompat-kb/webcompat_kb/bqhelpers.py
+++ b/jobs/webcompat-kb/webcompat_kb/bqhelpers.py
@@ -8,6 +8,9 @@ import google.auth
 from google.cloud import bigquery
 
 
+Json = Mapping[str, "Json"] | Sequence["Json"] | str | int | float | bool | None
+
+
 def get_client(bq_project_id: str) -> bigquery.Client:
     credentials, _ = google.auth.default(
         scopes=[
@@ -78,7 +81,7 @@ class BigQuery:
         self,
         table: bigquery.Table | str,
         schema: list[bigquery.SchemaField],
-        rows: Sequence[Mapping[str, Any]],
+        rows: Sequence[Mapping[str, Json]],
         overwrite: bool,
         dataset_id: Optional[str] = None,
     ) -> None:
@@ -112,7 +115,7 @@ class BigQuery:
         table = self.get_table_id(dataset_id, table)
 
         if self.write:
-            errors = self.client.insert_rows_json(table, rows)
+            errors = self.client.insert_rows(table, rows)
             if errors:
                 logging.error(errors)
         else:

--- a/jobs/webcompat-kb/webcompat_kb/bqhelpers.py
+++ b/jobs/webcompat-kb/webcompat_kb/bqhelpers.py
@@ -1,6 +1,8 @@
 import logging
+import uuid
 from dataclasses import dataclass
-from typing import Any, Iterable, Mapping, Optional, Sequence, cast
+from types import TracebackType
+from typing import Any, Iterable, Mapping, Optional, Self, Sequence, cast
 
 import google.auth
 from google.cloud import bigquery
@@ -141,3 +143,65 @@ class BigQuery:
         self, table: bigquery.Table | str, not_found_ok: bool = False
     ) -> None:
         return self.client.delete_table(table, not_found_ok=not_found_ok)
+
+    def temporary_table(
+        self,
+        schema: Iterable[bigquery.SchemaField],
+        rows: Optional[Sequence[Mapping[str, Any]]] = None,
+        dataset_id: Optional[str] = None,
+    ) -> "TemporaryTable":
+        return TemporaryTable(self, schema, rows, dataset_id)
+
+
+class TemporaryTable:
+    def __init__(
+        self,
+        client: BigQuery,
+        schema: Iterable[bigquery.SchemaField],
+        rows: Optional[Sequence[Mapping[str, Any]]] = None,
+        dataset_id: Optional[str] = None,
+    ):
+        self.client = client
+        self.schema = schema
+        self.rows = rows
+        self.dataset_id = dataset_id
+        self.name = f"tmp_{uuid.uuid4()}"
+        self.table: Optional[bigquery.Table] = None
+
+    def __enter__(self) -> Self:
+        self.table = bigquery.Table(
+            self.client.get_table_id(self.dataset_id, self.name), schema=self.schema
+        )
+        self.client.client.create_table(self.table)
+        if self.rows is not None:
+            self.client.client.load_table_from_json(
+                cast(Iterable[dict[str, Any]], self.rows),
+                self.table,
+            ).result()
+            logging.info(f"Wrote {len(self.rows)} records into {self.name}")
+        return self
+
+    def __exit__(
+        self,
+        type_: Optional[type[BaseException]],
+        value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        assert self.table is not None
+        logging.info(f"Removing temporary table {self.name}")
+        self.client.client.delete_table(self.table)
+        self.table = None
+
+    def query(
+        self,
+        query: str,
+        parameters: Optional[Sequence[bigquery.query._AbstractQueryParameter]] = None,
+    ) -> bigquery.table.RowIterator:
+        job_config = bigquery.QueryJobConfig(
+            default_dataset=f"{self.client.client.project}.{self.client.get_dataset(self.dataset_id)}"
+        )
+        if parameters is not None:
+            job_config.query_parameters = parameters
+
+        logging.debug(query)
+        return self.client.client.query(query, job_config=job_config).result()

--- a/jobs/webcompat-kb/webcompat_kb/main.py
+++ b/jobs/webcompat-kb/webcompat_kb/main.py
@@ -44,6 +44,7 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "jobs",
         nargs="*",
+        choices=list(ALL_JOBS.keys()),
         help="Jobs to run (defaults to all)",
     )
 

--- a/jobs/webcompat-kb/webcompat_kb/metric.py
+++ b/jobs/webcompat-kb/webcompat_kb/metric.py
@@ -51,13 +51,13 @@ def update_metric_history(client: BigQuery, bq_dataset_id: str, write: bool) -> 
             """
         rows = [
             {
-                "recorded_date": today.isoformat(),
-                "date": row.date.isoformat(),
+                "recorded_date": today,
+                "date": row.date,
                 "bug_count": row.bug_count,
-                "needs_diagnosis_score": str(row.needs_diagnosis_score),
-                "platform_score": str(row.platform_score),
-                "not_supported_score": str(row.not_supported_score),
-                "total_score": str(row.total_score),
+                "needs_diagnosis_score": row.needs_diagnosis_score,
+                "platform_score": row.platform_score,
+                "not_supported_score": row.not_supported_score,
+                "total_score": row.total_score,
             }
             for row in client.query(query)
         ]

--- a/jobs/webcompat-kb/webcompat_kb/utils.py
+++ b/jobs/webcompat-kb/webcompat_kb/utils.py
@@ -1,8 +1,13 @@
 import argparse
 import logging
 import sys
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Mapping
 
-from .bqhelpers import BigQuery, get_client
+from google.cloud import bigquery
+
+from .bqhelpers import BigQuery, Json, get_client
 
 
 def get_parser_create_test_dataset() -> argparse.ArgumentParser:
@@ -82,3 +87,156 @@ CLONE {src}
             client.query(query)
         else:
             logging.info(f"Would run query:{query}")
+
+
+@dataclass(frozen=True)
+class HistoryKey:
+    number: int
+    who: str
+    change_time: datetime
+
+
+def get_parser_backfill_history() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--log-level",
+        choices=["debug", "info", "warn", "error"],
+        default="info",
+        help="Log level",
+    )
+
+    parser.add_argument(
+        "--bq-project", dest="bq_project_id", help="BigQuery project id"
+    )
+    parser.add_argument(
+        "--bq-kb-src-dataset", help="BigQuery knowledge base source dataset id"
+    )
+    parser.add_argument(
+        "--bq-kb-dest-dataset", help="BigQuery knowledge base source dataset id"
+    )
+    parser.add_argument(
+        "--write", action="store_true", default=False, help="Write changes"
+    )
+    return parser
+
+
+def normalize_change(change: dict[str, str]) -> dict[str, str]:
+    if change["field_name"] == "keywords":
+        for key in ["added", "removed"]:
+            items = change[key].split(", ")
+            items.sort()
+            change[key] = ", ".join(items)
+
+    return change
+
+
+def backfill_history() -> None:
+    logging.basicConfig()
+
+    parser = get_parser_backfill_history()
+    args = parser.parse_args()
+    logging.getLogger().setLevel(logging.getLevelNamesMapping()[args.log_level.upper()])
+
+    src_dataset = args.bq_kb_src_dataset
+    dest_dataset = args.bq_kb_dest_dataset
+
+    client = BigQuery(get_client(args.bq_project_id), dest_dataset, args.write)
+
+    existing_records_dest: dict[HistoryKey, list[dict[str, str]]] = {}
+    existing_records_src: dict[HistoryKey, list[dict[str, str]]] = {}
+    for dataset, records in [
+        (dest_dataset, existing_records_dest),
+        (src_dataset, existing_records_src),
+    ]:
+        for row in client.query("""SELECT * FROM bugs_history""", dataset_id=dataset):
+            key = HistoryKey(row.number, row.who, row.change_time)
+            if key in records:
+                logging.warning(
+                    f"Got duplicate src data for {key}: {row.changes}, {records[key]}"
+                )
+                for change in row.changes:
+                    if change not in records[key]:
+                        records[key].append(change)
+            else:
+                records[key] = row.changes
+
+    logging.info(
+        f"Started with {len(existing_records_src)} records in {src_dataset} and {len(existing_records_dest)} in {dest_dataset}"
+    )
+
+    new_records: list[tuple[datetime, Mapping[str, Json]]] = []
+
+    new_count = 0
+    updated_count = 0
+    unchanged_count = 0
+    for key, changes in existing_records_src.items():
+        if key in existing_records_dest:
+            existing = [
+                normalize_change(change) for change in existing_records_dest[key]
+            ]
+            new = [normalize_change(change) for change in changes]
+            if new == existing or (
+                all(item in existing for item in new)
+                and all(item in new for item in existing)
+            ):
+                unchanged_count += 1
+            else:
+                missing = [item for item in existing if item not in new]
+                if missing:
+                    logging.warning(
+                        f"Updating record {key}, merging {new} with {existing}"
+                    )
+                    changes.extend(missing)
+                updated_count += 1
+        else:
+            new_count += 1
+        new_records.append(
+            (
+                key.change_time,
+                {
+                    "number": key.number,
+                    "who": key.who,
+                    "change_time": key.change_time.isoformat(),
+                    "changes": changes,
+                },
+            )
+        )
+
+    for key, changes in existing_records_dest.items():
+        if key not in existing_records_src:
+            unchanged_count += 1
+            new_records.append(
+                (
+                    key.change_time,
+                    {
+                        "number": key.number,
+                        "who": key.who,
+                        "change_time": key.change_time.isoformat(),
+                        "changes": changes,
+                    },
+                )
+            )
+
+    logging.info(
+        f"Writing {len(new_records)} records to {dest_dataset}, {unchanged_count} unchanged, {updated_count} updated, {new_count} new"
+    )
+
+    new_records.sort()
+    schema = [
+        bigquery.SchemaField("number", "INTEGER", mode="REQUIRED"),
+        bigquery.SchemaField("who", "STRING", mode="REQUIRED"),
+        bigquery.SchemaField("change_time", "TIMESTAMP", mode="REQUIRED"),
+        bigquery.SchemaField(
+            "changes",
+            "RECORD",
+            mode="REPEATED",
+            fields=[
+                bigquery.SchemaField("field_name", "STRING", mode="REQUIRED"),
+                bigquery.SchemaField("added", "STRING", mode="REQUIRED"),
+                bigquery.SchemaField("removed", "STRING", mode="REQUIRED"),
+            ],
+        ),
+    ]
+    client.write_table(
+        "bugs_history", schema, [item[1] for item in new_records], overwrite=True
+    )


### PR DESCRIPTION
Some things I had locally that didn't fit into other PRs :)

More substantive changes are:
* A context manager for temporary tables. This allows them to be written even when passing `--no-write` e.g. for local testing.
* Converting `BigQuery.insert_rows` away from `Client.insert_rows_json`. This was the root cause of some of the type conversion mistakes we missed. Now `insert_rows` will generally type convert automatically. `BigQuery.write_table` will still not type convert, but we add a `Json` type so that passing in Json-incompatible data types is likely to be caught by the type checker.
* A utility job for merging history from one table to another. This is useful when we start collecting new data in the history; we can write the updated data to a temporary table and then merge in the missing rows. Just overwriting might remove some rows corresponding to bugs we previously tracked but don't track any longer (such bugs will typically not get the new data either; maybe we should be looking to do better here).

Suggest reviewing one commit at a time.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
