### PR TITLE
Require getting a lock before running the ETL

### DIFF
--- a/jobs/webcompat-kb/webcompat_kb/main.py
+++ b/jobs/webcompat-kb/webcompat_kb/main.py
@@ -1,6 +1,12 @@
 import argparse
 import logging
 import sys
+import time
+import traceback
+from types import TracebackType
+from typing import Optional
+
+from google.cloud import bigquery
 
 # These imports are required to populate ALL_JOBS
 from . import bugzilla, crux, metric, metric_changes  # noqa: F401
@@ -32,6 +38,12 @@ def get_parser() -> argparse.ArgumentParser:
         action="store_false",
         default=True,
         help="Don't write updates to BigQuery",
+    )
+
+    parser.add_argument(
+        "--wait-lock",
+        action="store_true",
+        help="Wait to acquire the ETL lock (not intended for prod)",
     )
 
     parser.add_argument(
@@ -80,6 +92,117 @@ def set_default_args(parser: argparse.ArgumentParser, args: argparse.Namespace) 
         sys.exit(1)
 
 
+class LockError(Exception):
+    pass
+
+
+class EtlLock:
+    def __init__(
+        self, client: bigquery.Client, kb_dataset_id: str, write: bool, wait: bool
+    ):
+        self.client = BigQuery(client, kb_dataset_id, write)
+        self.write = write
+        self.wait = wait
+        # This acts as an early check that we have auth credentials for GH, even if we won't take a lock
+        self.table = self.client.ensure_table(
+            "etl_lock",
+            schema=[
+                bigquery.SchemaField("lock_time", "DATETIME"),
+            ],
+        )
+        self.lock_time = None
+
+    def __enter__(self) -> None:
+        if not self.write:
+            logging.debug("Not writing, so ETL lock is not required")
+            return
+        first = True
+        while True:
+            # Updates are serialized by transactions whereas inserts are not
+            # We use an insert to check we have at least one row, but then
+            # use the (serialized) updates to acquire the lock
+            try:
+                result = self.client.query(f"""
+DECLARE update_count INT64 DEFAULT 0;
+BEGIN TRANSACTION;
+
+INSERT {self.table.table_id} (lock_time)
+SELECT NULL
+FROM UNNEST([1])
+WHERE NOT EXISTS (SELECT 1 FROM {self.table.table_id});
+
+UPDATE {self.table.table_id}
+SET lock_time = CURRENT_DATETIME()
+WHERE lock_time IS NULL;
+SET update_count = @@row_count;
+
+COMMIT TRANSACTION;
+
+SELECT update_count, lock_time FROM {self.table.table_id}
+""")
+            except Exception:
+                # This can happen if there's a simultaneous modification in the transaction
+                pass
+            else:
+                row = list(result)[0]
+                if row.update_count == 1:
+                    self.lock_time = row.lock_time
+                    logging.info(f"Acquired lock with timestamp {self.lock_time}")
+                    return
+
+            if not self.wait:
+                raise LockError(
+                    f"Can't run, another ETL process is running; started at time {row.lock_time}"
+                )
+            if first:
+                logging.info(
+                    f"Waiting for lock, current lock was acquired at {row.lock_time}"
+                )
+                first = False
+            # This doesn't guarantee we ever get the lock; if another process happens to acquire the lock whilst we're
+            # sleeping we'll lose out. But the main case we care about is being able to run local jobs when the airflow
+            # task is not running, so as long as this is shorter than the setup time of airflow we're in a good place
+            time.sleep(5)
+
+    def __exit__(
+        self,
+        type_: Optional[type[BaseException]],
+        value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        failed = False
+        if self.lock_time is not None:
+            try:
+                result = self.client.query(
+                    f"""
+DECLARE update_count INT64 DEFAULT 0;
+BEGIN TRANSACTION;
+UPDATE {self.table.table_id}
+SET lock_time = NULL
+WHERE lock_time = @lock_time;
+SET update_count = @@row_count;
+COMMIT TRANSACTION;
+
+SELECT update_count
+""",
+                    parameters=[
+                        bigquery.ScalarQueryParameter(
+                            "lock_time", "DATETIME", self.lock_time
+                        )
+                    ],
+                )
+            except Exception:
+                # This can happen if there are multiple concurrent transactions
+                failed = True
+            else:
+                failed = list(result)[0].update_count != 1
+            if failed:
+                logging.warning(
+                    f"Expected to clear lock with lock_time {self.lock_time}, but failed"
+                )
+            self.lock_time = None
+
+
 def main() -> None:
     logging.basicConfig()
 
@@ -99,21 +222,26 @@ def main() -> None:
 
         client = get_client(args.bq_project_id)
 
-        for job_name, job in jobs.items():
-            logging.info(f"Running job {job_name}")
-            bq_client = BigQuery(client, job.default_dataset(args), args.write)
+        with EtlLock(client, args.bq_kb_dataset, args.write, args.wait_lock):
+            for job_name, job in jobs.items():
+                logging.info(f"Running job {job_name}")
+                bq_client = BigQuery(client, job.default_dataset(args), args.write)
 
-            try:
-                job.main(bq_client, args)
-            except Exception as e:
-                if args.pdb:
-                    raise
-                failed.append(job_name)
-                logging.error(e)
+                try:
+                    job.main(bq_client, args)
+                except Exception as e:
+                    if args.pdb:
+                        raise
+                    failed.append(job_name)
+                    traceback.print_exc()
+                    logging.error(e)
+    except LockError as e:
+        logging.info(str(e))
+        logging.error("Failed to acquire ETL lock, exiting")
+        sys.exit(1)
     except Exception:
         if args.pdb:
             import pdb
-            import traceback
 
             traceback.print_exc()
             pdb.post_mortem()


### PR DESCRIPTION
This is a bad idea

Sometimes we want to run specific ETL jobs locally e.g. when updating the scoring logic. When doing this we don't want the ETL itself updating data, as a lot of the logic assumes that we don't have concurrent writes.

This approach uses a very simple implementation of a lock table: essentially a table that has zero or one rows at a given time. If there's an existing row the lock is taken and the process either exits or polls the lock until it can be acquired.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
