### PR TITLE
Update base image for bq2sftp

### DIFF
--- a/jobs/bq2sftp/Dockerfile
+++ b/jobs/bq2sftp/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/cloud-sdk:357.0.0
+FROM google/cloud-sdk:slim
 MAINTAINER Jeff Klukas <jklukas@mozilla.com>
 
 # https://github.com/mozilla-services/Dockerflow/blob/master/docs/building-container.md


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1969009

Updates the base Docker image for bq2sftp to `google/cloud-sdk:slim`, as the currently used version (357.0.0) includes an outdated version of curl/libssh that prevents us from pointing the job to a new SFTP server.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
