### PR TITLE
Add a site-ranks-update manual job

### DIFF
--- a/jobs/webcompat-kb/webcompat_kb/bqhelpers.py
+++ b/jobs/webcompat-kb/webcompat_kb/bqhelpers.py
@@ -35,6 +35,7 @@ class RangePartition:
 class BigQuery:
     def __init__(self, client: bigquery.Client, default_dataset_id: str, write: bool):
         self.client = client
+        self.project_id = client.project
         self.default_dataset_id = default_dataset_id
         self.write = write
 


### PR DESCRIPTION
This is designed to make it easier to automatically update to a new version of site rank data, on the basis that all data is represented as a yyyymm integer.

The job automatcially creates a new version of the routine containing the current yyyymm value that we're using; updates a copy of `scored_site_reports` to use the new version, and then runs the rescoring logic to record the metric changes resulting from the change in the site rank data.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.
