### PR TITLE
Unbreak webcompat job by temporary removing interop import

### DIFF
--- a/jobs/webcompat-kb/webcompat_kb/main.py
+++ b/jobs/webcompat-kb/webcompat_kb/main.py
@@ -13,7 +13,6 @@ from . import (
     standards_positions,  # noqa: F401
     metric_rescore,  # noqa: F401
     chrome_use_counters,  # noqa: F401
-    interop,  # noqa: F401
 )
 from .base import ALL_JOBS, EtlJob, dataset_arg, project_arg
 from .bqhelpers import get_client, BigQuery


### PR DESCRIPTION
Since we don't have required parameters in the airflow config yet, the job is failing. Removing the import to temporary unbreak it.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.

**Note for deployments:** In order to push images built by this PR, the user who merges the PR
must be in the [telemetry Github team](https://github.com/orgs/mozilla/teams/telemetry).
This is because deploys depend on the
[data-eng-airflow-gcr CircleCI context](https://app.circleci.com/settings/organization/github/mozilla/contexts/e1876f84-dfea-47ce-b950-a9eb9e0d4d64).
See [DENG-8850](https://mozilla-hub.atlassian.net/browse/DENG-8850) for additional discussion.
