### PR TITLE
Import all recently changed bugs in bugzilla ETL

### DIFF
--- a/jobs/webcompat-kb/webcompat_kb/bugzilla.py
+++ b/jobs/webcompat-kb/webcompat_kb/bugzilla.py
@@ -292,9 +292,12 @@ BUG_QUERIES: Mapping[str, Mapping[str, str | list[str]]] = {
         "f10": "bug_status",
         "o10": "changedafter",
         "v10": "2020-01-01",
-        "f11": "resolution",
-        "o11": "isempty",
-        "f12": "CP",
+        "f11": "delta_ts",
+        "o11": "greaterthaneq",
+        "v11": "2025-01-01",
+        "f12": "resolution",
+        "o13": "isempty",
+        "f13": "CP",
     },
 }
 


### PR DESCRIPTION
This ensures we don't miss platform feature bugs that were resolved a long time ago, but are newly associated with an Interop request or similar.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is
  referenced, the pull request should include the bug number in the title)
- [ ] Scan the PR and verify that no changes (particularly to
  `.circleci/config.yml`) will cause environment variables (particularly
  credentials) to be exposed in test logs
- [ ] Ensure the container image will be using permissions granted to
  [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/)
  responsibly.

**Note for deployments:** In order to push images built by this PR, the user who merges the PR
must be in the [telemetry Github team](https://github.com/orgs/mozilla/teams/telemetry).
This is because deploys depend on the
[data-eng-airflow-gcr CircleCI context](https://app.circleci.com/settings/organization/github/mozilla/contexts/e1876f84-dfea-47ce-b950-a9eb9e0d4d64).
See [DENG-8850](https://mozilla-hub.atlassian.net/browse/DENG-8850) for additional discussion.
