### PR TITLE
DENG-10878 Format serp_categories field in suggestion data

### DIFF
--- a/jobs/quicksuggest2bq/quicksuggest2bq/main.py
+++ b/jobs/quicksuggest2bq/quicksuggest2bq/main.py
@@ -101,6 +101,10 @@ def download_suggestions(client: kinto_http.Client) -> Iterator[KintoSuggestion]
                     {"keyword": kw, "count": count}
                     for kw, count in suggestion_data.get("full_keywords", [])
                 ],
+                "serp_categories": [
+                    {"category": category_id}
+                    for category in suggestion_data.get("serp_categories", [])
+                ],
             }
             yield KintoSuggestion(**suggestion)
 

--- a/jobs/quicksuggest2bq/quicksuggest2bq/main.py
+++ b/jobs/quicksuggest2bq/quicksuggest2bq/main.py
@@ -103,7 +103,7 @@ def download_suggestions(client: kinto_http.Client) -> Iterator[KintoSuggestion]
                 ],
                 "serp_categories": [
                     {"category": category_id}
-                    for category in suggestion_data.get("serp_categories", [])
+                    for category_id in suggestion_data.get("serp_categories", [])
                 ],
             }
             yield KintoSuggestion(**suggestion)

--- a/jobs/quicksuggest2bq/tests/test_main.py
+++ b/jobs/quicksuggest2bq/tests/test_main.py
@@ -136,7 +136,7 @@ class TestMain:
     def test_suggestion_serp_categories(self, mocked_kinto_client):
         suggestions = list(download_suggestions(mocked_kinto_client))
         assert suggestions[0].serp_categories[0]["category"] == 1
-        assert suggestions[0].serp_categories[0]["category"] == 2
+        assert suggestions[0].serp_categories[1]["category"] == 2
 
     def test_suggestion_score(self, mocked_kinto_client):
         suggestions = list(download_suggestions(mocked_kinto_client))

--- a/jobs/quicksuggest2bq/tests/test_main.py
+++ b/jobs/quicksuggest2bq/tests/test_main.py
@@ -135,7 +135,8 @@ class TestMain:
 
     def test_suggestion_serp_categories(self, mocked_kinto_client):
         suggestions = list(download_suggestions(mocked_kinto_client))
-        assert suggestions[0].serp_categories == SERP_CATEGORIES
+        assert suggestions[0].serp_categories[0]["category"] == 1
+        assert suggestions[0].serp_categories[0]["category"] == 2
 
     def test_suggestion_score(self, mocked_kinto_client):
         suggestions = list(download_suggestions(mocked_kinto_client))


### PR DESCRIPTION
In the `quicksuggest2bq` job, it looks like in old data the `serp_categories` field was always empty, so we never had to properly format it. Now that we are receiving some data in this field, this change handles the necessary formatting.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs

- [ ] Ensure the container image will be using permissions granted to [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/) responsibly.
