### PR TITLE
fix(fxci-etl): catch Taskcluster internal errors while processing tas…

### DIFF
--- a/jobs/fxci-taskcluster-export/fxci_etl/pulse/handler.py
+++ b/jobs/fxci-taskcluster-export/fxci_etl/pulse/handler.py
@@ -207,5 +207,13 @@ class BigQueryHandler(PulseHandler):
                 # FIXME insert isn't atomic, so if this fails we can end up with duplicate records
                 taskdef_loader.insert(taskdef_records)
                 self.task_ids.clear()
+            except taskcluster.exceptions.TaskclusterRestFailure as e:
+                if e.status_code is not None and e.status_code >= 500:
+                    logger.warning(
+                        f"Transient Taskcluster API error ({e.status_code}) fetching task definitions; "
+                        f"{len(self.task_ids)} task IDs will be retried next run."
+                    )
+                else:
+                    raise
             finally:
                 self._taskids_backup.upload_from_string(json.dumps(list(self.task_ids)))


### PR DESCRIPTION
…k backup

Taskcluster is returning 500s for this request. As restoring the backup data isn't super important anyway, exceptions here should fail the whole Airflow DAG.

Bug: 2041070

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs

- [ ] Ensure the container image will be using permissions granted to [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/) responsibly.
