### PR TITLE
fix(fxci-etl): reduce task-definition chunk size

### DIFF
--- a/jobs/fxci-taskcluster-export/fxci_etl/pulse/handler.py
+++ b/jobs/fxci-taskcluster-export/fxci_etl/pulse/handler.py
@@ -194,7 +194,7 @@ class BigQueryHandler(PulseHandler):
             self.run_records = []
 
         if self.task_ids:
-            taskdef_loader = BigQueryLoader(self.config, "taskdefinitions", chunk_size=1000)
+            taskdef_loader = BigQueryLoader(self.config, "taskdefinitions", chunk_size=100)
             taskdefs = []
             def paginationHandler(response):
                 taskdefs.extend(response["tasks"])


### PR DESCRIPTION
We happened to hit a batch of 1000 tasks whose task definitions exceed BigQueries' 10MB request limit.

Bug: 2041074

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs

- [ ] Ensure the container image will be using permissions granted to [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/) responsibly.
