### PR TITLE
Bug 2041074 - Batch FXCI BigQuery inserts by size

### DIFF
--- a/jobs/fxci-taskcluster-export/fxci_etl/loaders/bigquery.py
+++ b/jobs/fxci-taskcluster-export/fxci_etl/loaders/bigquery.py
@@ -1,7 +1,6 @@
 import base64
 import json
 from dataclasses import asdict
-from itertools import batched
 from pprint import pprint
 from textwrap import dedent
 
@@ -19,12 +18,57 @@ from fxci_etl.schemas import Record, get_record_cls, generate_schema
 from fxci_etl.config import Config
 
 
+MAX_INSERT_REQUEST_BYTES = 9_000_000
+
+
+def _json_size(obj: object) -> int:
+    return len(json.dumps(obj, separators=(",", ":")).encode("utf-8"))
+
+
+def _insert_batches(
+    records: list[dict], max_count: int, max_bytes: int
+) -> list[list[dict]]:
+    batches = []
+    batch = []
+    batch_size = 0
+
+    for record in records:
+        record_size = _json_size(record)
+        if batch and (
+            len(batch) >= max_count or batch_size + record_size > max_bytes
+        ):
+            batches.append(batch)
+            batch = []
+            batch_size = 0
+
+        if record_size > max_bytes:
+            logger.warning(
+                f"Single BigQuery row is {record_size} bytes; "
+                "inserting it by itself."
+            )
+
+        batch.append(record)
+        batch_size += record_size
+
+    if batch:
+        batches.append(batch)
+
+    return batches
+
+
 class BigQueryLoader:
     DEFAULT_CHUNK_SIZE = 5000
 
-    def __init__(self, config: Config, table_type: str, chunk_size: int = DEFAULT_CHUNK_SIZE):
+    def __init__(
+        self,
+        config: Config,
+        table_type: str,
+        chunk_size: int = DEFAULT_CHUNK_SIZE,
+        max_insert_bytes: int = MAX_INSERT_REQUEST_BYTES,
+    ):
         self.config = config
         self.chunk_size = chunk_size
+        self.max_insert_bytes = max_insert_bytes
 
         if config.bigquery.credentials:
             self.client = Client.from_service_account_info(
@@ -123,14 +167,15 @@ class BigQueryLoader:
 
         logger.info(f"{len(records)} records to insert into table '{self.table_name}'")
 
-        # There's a 10MB limit on the `insert_rows` request, submit rows in
-        # batches to avoid exceeding it.
+        # There's a 10MB limit on the `insert_rows` request. Submit rows in
+        # batches by both count and serialized size to avoid exceeding it.
         errors = []
-        for batch in batched(records, self.chunk_size):
+        rows = [asdict(row) for row in records]
+        for batch in _insert_batches(rows, self.chunk_size, self.max_insert_bytes):
             logger.debug(f"Inserting batch of {len(batch)} records")
             errors.extend(
                 self.client.insert_rows(
-                    self.table, [asdict(row) for row in batch], retry=False
+                    self.table, batch, retry=False
                 )
             )
 

--- a/jobs/fxci-taskcluster-export/fxci_etl/loaders/bigquery.py
+++ b/jobs/fxci-taskcluster-export/fxci_etl/loaders/bigquery.py
@@ -18,46 +18,13 @@ from fxci_etl.schemas import Record, get_record_cls, generate_schema
 from fxci_etl.config import Config
 
 
-MAX_INSERT_REQUEST_BYTES = 9_000_000
-
-
 def _json_size(obj: object) -> int:
     return len(json.dumps(obj, separators=(",", ":")).encode("utf-8"))
 
 
-def _insert_batches(
-    records: list[dict], max_count: int, max_bytes: int
-) -> list[list[dict]]:
-    batches = []
-    batch = []
-    batch_size = 0
-
-    for record in records:
-        record_size = _json_size(record)
-        if batch and (
-            len(batch) >= max_count or batch_size + record_size > max_bytes
-        ):
-            batches.append(batch)
-            batch = []
-            batch_size = 0
-
-        if record_size > max_bytes:
-            logger.warning(
-                f"Single BigQuery row is {record_size} bytes; "
-                "inserting it by itself."
-            )
-
-        batch.append(record)
-        batch_size += record_size
-
-    if batch:
-        batches.append(batch)
-
-    return batches
-
-
 class BigQueryLoader:
     DEFAULT_CHUNK_SIZE = 5000
+    MAX_INSERT_REQUEST_BYTES = 9_000_000
 
     def __init__(
         self,
@@ -87,6 +54,32 @@ class BigQueryLoader:
         self.table = self.ensure_table(table_type)
         self.bucket = self.storage_client.bucket(config.storage.bucket)
         self._record_backup = self.bucket.blob(f"failed-bq-records.{table_type}.json")
+
+    def _chunk_batches(self, records: list[dict]):
+        batch = []
+        batch_size = 0
+
+        for record in records:
+            record_size = _json_size(record)
+            if batch and (
+                len(batch) >= self.chunk_size
+                or batch_size + record_size > self.max_insert_bytes
+            ):
+                yield batch
+                batch = []
+                batch_size = 0
+
+            if record_size > self.max_insert_bytes:
+                logger.warning(
+                    f"Single BigQuery row is {record_size} bytes; "
+                    "inserting it by itself."
+                )
+
+            batch.append(record)
+            batch_size += record_size
+
+        if batch:
+            yield batch
 
     def ensure_table(self, table_type: str) -> Table:
         """Ensures the specified table exists and returns it.
@@ -171,7 +164,7 @@ class BigQueryLoader:
         # batches by both count and serialized size to avoid exceeding it.
         errors = []
         rows = [asdict(row) for row in records]
-        for batch in _insert_batches(rows, self.chunk_size, self.max_insert_bytes):
+        for batch in self._chunk_batches(rows):
             logger.debug(f"Inserting batch of {len(batch)} records")
             errors.extend(
                 self.client.insert_rows(

--- a/jobs/fxci-taskcluster-export/test/test_bigquery_loader.py
+++ b/jobs/fxci-taskcluster-export/test/test_bigquery_loader.py
@@ -1,10 +1,17 @@
-from fxci_etl.loaders.bigquery import _insert_batches
+from types import SimpleNamespace
+
+from fxci_etl.loaders.bigquery import BigQueryLoader
 
 
-def test_insert_batches_respect_record_count():
+def _make_loader(chunk_size, max_bytes):
+    return SimpleNamespace(chunk_size=chunk_size, max_insert_bytes=max_bytes)
+
+
+def test_chunk_batches_respect_record_count():
     records = [{"value": "x"} for _ in range(5)]
+    loader = _make_loader(chunk_size=2, max_bytes=1000)
 
-    batches = _insert_batches(records, max_count=2, max_bytes=1000)
+    batches = list(BigQueryLoader._chunk_batches(loader, records))
 
     assert batches == [
         [{"value": "x"}, {"value": "x"}],
@@ -13,14 +20,15 @@ def test_insert_batches_respect_record_count():
     ]
 
 
-def test_insert_batches_respect_serialized_size():
+def test_chunk_batches_respect_serialized_size():
     records = [
         {"value": "x" * 30},
         {"value": "y" * 30},
         {"value": "z" * 5},
     ]
+    loader = _make_loader(chunk_size=100, max_bytes=65)
 
-    batches = _insert_batches(records, max_count=100, max_bytes=65)
+    batches = list(BigQueryLoader._chunk_batches(loader, records))
 
     assert batches == [
         [{"value": "x" * 30}],
@@ -28,13 +36,14 @@ def test_insert_batches_respect_serialized_size():
     ]
 
 
-def test_insert_batches_allow_oversized_single_row():
+def test_chunk_batches_allow_oversized_single_row():
     records = [
         {"value": "x" * 100},
         {"value": "y"},
     ]
+    loader = _make_loader(chunk_size=100, max_bytes=50)
 
-    batches = _insert_batches(records, max_count=100, max_bytes=50)
+    batches = list(BigQueryLoader._chunk_batches(loader, records))
 
     assert batches == [
         [{"value": "x" * 100}],

--- a/jobs/fxci-taskcluster-export/test/test_bigquery_loader.py
+++ b/jobs/fxci-taskcluster-export/test/test_bigquery_loader.py
@@ -1,0 +1,42 @@
+from fxci_etl.loaders.bigquery import _insert_batches
+
+
+def test_insert_batches_respect_record_count():
+    records = [{"value": "x"} for _ in range(5)]
+
+    batches = _insert_batches(records, max_count=2, max_bytes=1000)
+
+    assert batches == [
+        [{"value": "x"}, {"value": "x"}],
+        [{"value": "x"}, {"value": "x"}],
+        [{"value": "x"}],
+    ]
+
+
+def test_insert_batches_respect_serialized_size():
+    records = [
+        {"value": "x" * 30},
+        {"value": "y" * 30},
+        {"value": "z" * 5},
+    ]
+
+    batches = _insert_batches(records, max_count=100, max_bytes=65)
+
+    assert batches == [
+        [{"value": "x" * 30}],
+        [{"value": "y" * 30}, {"value": "z" * 5}],
+    ]
+
+
+def test_insert_batches_allow_oversized_single_row():
+    records = [
+        {"value": "x" * 100},
+        {"value": "y"},
+    ]
+
+    batches = _insert_batches(records, max_count=100, max_bytes=50)
+
+    assert batches == [
+        [{"value": "x" * 100}],
+        [{"value": "y"}],
+    ]


### PR DESCRIPTION
Follow-up to #526.

The `fxci_pulse_export` run at 2026-05-20 18:30 UTC still failed with a 413 while inserting a batch of 100 `task_definitions_v1` rows. The malformed hg-push task definitions observed today serialize to about 9.44 MB each, so any batch with more than one of those rows can exceed BigQuery insertAll's 10 MB request limit.

This keeps the existing row-count chunking, but also batches by serialized row size with a 9 MB target. Rows larger than the target are inserted alone so they still have a chance to fit under BigQuery's hard request limit.

Validation:
- `uv run --python 3.12 --with-requirements requirements/test.txt --with-editable . pytest`
- `git diff --check`

Bug: 2041074