### PR TITLE
Add an alias for web_feature field

### DIFF
--- a/jobs/webcompat-kb/webcompat_kb/standards_positions.py
+++ b/jobs/webcompat-kb/webcompat_kb/standards_positions.py
@@ -21,7 +21,7 @@ class StandardsPosition(pydantic.BaseModel):
     title: str
     url: Optional[str]
     explainer: Optional[str]
-    web_feature: Optional[str]
+    web_feature: Optional[str] = pydantic.Field(default=None, alias="web-feature")
     mdn: Optional[str]
     caniuse: Optional[str]
     bug: Optional[str]


### PR DESCRIPTION
The job has been failing with:

```
[2026-05-26, 16:17:32 UTC] {pod_manager.py:477} INFO - [base] INFO:root:Running job standards-positions
[2026-05-26, 16:17:32 UTC] {pod_manager.py:477} INFO - [base] INFO:httpx:HTTP Request: GET https://api.github.com/repos/mozilla/standards-positions/contents/merged-data.json?ref=gh-pages "HTTP/1.1 200 OK"
[2026-05-26, 16:17:32 UTC] {pod_manager.py:477} INFO - [base] INFO:httpx:HTTP Request: GET https://raw.githubusercontent.com/mozilla/standards-positions/gh-pages/merged-data.json "HTTP/1.1 200 OK"
[2026-05-26, 16:17:32 UTC] {pod_manager.py:477} INFO - [base] ERROR:root:1 validation error for StandardsPosition
[2026-05-26, 16:17:32 UTC] {pod_manager.py:477} INFO - [base] web_feature
[2026-05-26, 16:17:32 UTC] {pod_manager.py:477} INFO - [base]   Field required [type=missing, input_value={'position': 'positive', ...eir online experience."}, input_type=dict]
[2026-05-26, 16:17:32 UTC] {pod_manager.py:477} INFO - [base]     For further information visit https://errors.pydantic.dev/2.13/v/missing
```
Looks like the json has `"web-feature": null` field and we're expecting `web_feature`. Not sure if this is the right fix, but I've added an alias to map the two together as well as default null value and run it locally to unbreak the job.

