### PR TITLE
[SPONS-162] Add suggestion uuids to quicksuggest2bq job, and log don't error on new kinto suggestion fields

### DIFF
--- a/jobs/quicksuggest2bq/quicksuggest2bq/main.py
+++ b/jobs/quicksuggest2bq/quicksuggest2bq/main.py
@@ -39,6 +39,7 @@ class KintoSuggestion:
     iab_category: str
     icon: str
     id: int
+    uuid: str
     keywords: List[str]
     title: str
     url: str
@@ -157,6 +158,7 @@ def store_suggestions(
             bigquery.SchemaField("icon", "STRING"),
             bigquery.SchemaField("impression_url", "STRING"),
             bigquery.SchemaField("id", "INTEGER"),
+            bigquery.SchemaField("uuid", "STRING"),
             bigquery.SchemaField("keywords", "STRING", "REPEATED"),
             bigquery.SchemaField(
                 "full_keywords",

--- a/jobs/quicksuggest2bq/quicksuggest2bq/main.py
+++ b/jobs/quicksuggest2bq/quicksuggest2bq/main.py
@@ -8,7 +8,7 @@ import kinto_http
 import logging
 import requests
 
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, fields
 from google.api_core.exceptions import BadRequest
 from google.cloud import bigquery
 from typing import Any, Dict, Iterator, List, Optional
@@ -29,10 +29,12 @@ class FullKeyword:
 class KintoSuggestion:
     """Class that holds information about a Suggestion returned by Kinto."""
 
-    # By being explicit about the fields we expect and not
-    # just storing the raw JSON, the conversion will fail
-    # if there's new unexpected fields, ensuring we take the
-    # appropriate actions to update the table schemas.
+    # By being explicit about the fields we expect and not just storing the
+    # raw JSON, we control exactly what gets written to BigQuery. New fields
+    # added to the Remote Settings payload are ignored by `from_dict` (and
+    # logged) so that additive schema changes don't break the job. To start
+    # ingesting a new field, add it here and to the BigQuery schema in
+    # `store_suggestions`.
     advertiser: str
     iab_category: str
     icon: str
@@ -55,6 +57,24 @@ class KintoSuggestion:
     # suggestion.
     serp_categories: Optional[List[int]] = None
 
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "KintoSuggestion":
+        """Build a KintoSuggestion from a raw record.
+
+        Fields that aren't declared on the dataclass are dropped (and logged)
+        instead of raising, so that additive changes to the Remote Settings
+        payload don't break the job. Such fields are not ingested until they're
+        added to the dataclass and the BigQuery schema.
+        """
+        known_fields = {field.name for field in fields(cls)}
+        unknown_fields = sorted(set(data) - known_fields)
+        if unknown_fields:
+            logging.warning(
+                "Ignoring unknown field(s) in suggestion: %s",
+                ", ".join(unknown_fields),
+            )
+        return cls(**{key: value for key, value in data.items() if key in known_fields})
+
 
 def download_suggestions(client: kinto_http.Client) -> Iterator[KintoSuggestion]:
     """Get records, download attachments and return the suggestions."""
@@ -66,9 +86,7 @@ def download_suggestions(client: kinto_http.Client) -> Iterator[KintoSuggestion]
     # Load records for both "type: data" and "type: offline-expansion-data".
     # See details in: https://mozilla-hub.atlassian.net/browse/CONSVC-1818
     data_records = [
-        record
-        for record in client.get_records()
-        if record["type"] in ["amp"]
+        record for record in client.get_records() if record["type"] in ["amp"]
     ]
 
     # Make use of connection pooling because all requests go to the same host
@@ -92,8 +110,9 @@ def download_suggestions(client: kinto_http.Client) -> Iterator[KintoSuggestion]
             continue
 
         # Each attachment is a list of suggestion objects and each suggestion
-        # object contains a list of keywords. Load the suggestions into pydantic
-        # model instances to discard all fields which we don't care about here.
+        # object contains a list of keywords. Load the suggestions into
+        # KintoSuggestion dataclass instances to discard all fields which we
+        # don't care about here.
         for suggestion_data in response.json():
             suggestion: Dict[str, Any] = {
                 **suggestion_data,
@@ -106,7 +125,7 @@ def download_suggestions(client: kinto_http.Client) -> Iterator[KintoSuggestion]
                     for category_id in suggestion_data.get("serp_categories", [])
                 ],
             }
-            yield KintoSuggestion(**suggestion)
+            yield KintoSuggestion.from_dict(suggestion)
 
 
 def store_suggestions(

--- a/jobs/quicksuggest2bq/tests/test_main.py
+++ b/jobs/quicksuggest2bq/tests/test_main.py
@@ -99,8 +99,18 @@ def mocked_kinto_client_icon_only(mocker: MockerFixture):
 
 class TestMain:
     def test_suggestion_breaks_on_unknown_fields(self):
+        # Constructing directly still rejects unknown fields...
         with pytest.raises(Exception):
             KintoSuggestion(**{"does_not_exist": "i am sure!"})
+
+    def test_from_dict_ignores_unknown_fields(self):
+        # ...but `from_dict` tolerates additive schema changes by dropping
+        # fields that aren't declared on the dataclass.
+        suggestion = KintoSuggestion.from_dict(
+            {**SAMPLE_SUGGESTION, "brand_new_field": "ignore me"}
+        )
+        assert suggestion.id == SAMPLE_SUGGESTION["id"]
+        assert not hasattr(suggestion, "brand_new_field")
 
     def test_suggestion_properties_are_properly_parsed(self):
         KintoSuggestion(**SAMPLE_SUGGESTION)

--- a/jobs/quicksuggest2bq/tests/test_main.py
+++ b/jobs/quicksuggest2bq/tests/test_main.py
@@ -10,6 +10,7 @@ SERP_CATEGORIES = [1, 2]
 
 SAMPLE_SUGGESTION = {
     "id": 2802,
+    "uuid": "8d3a1b2c-4e5f-6a7b-8c9d-0e1f2a3b4c5d",
     "url": "https://www.example.com",
     "click_url": "https://example.com/click",
     "impression_url": "https://example.com/impression",
@@ -29,6 +30,7 @@ SAMPLE_SUGGESTION = {
 
 SAMPLE_WIKIPEDIA_SUGGESTION = {
     "id": 0,
+    "uuid": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
     "url": "https://www.wikipedia.org",
     "iab_category": "5 - Education",
     "icon": "4072021",
@@ -153,6 +155,12 @@ class TestMain:
         assert len(suggestions) == 2
         assert suggestions[0].score == SAMPLE_SUGGESTION["score"]
         assert suggestions[1].score == SAMPLE_WIKIPEDIA_SUGGESTION["score"]
+
+    def test_suggestion_uuid(self, mocked_kinto_client):
+        suggestions = list(download_suggestions(mocked_kinto_client))
+        assert len(suggestions) == 2
+        assert suggestions[0].uuid == SAMPLE_SUGGESTION["uuid"]
+        assert suggestions[1].uuid == SAMPLE_WIKIPEDIA_SUGGESTION["uuid"]
 
     def test_icon_records_not_downloaded(self, mocked_kinto_client_icon_only):
         suggestions = list(download_suggestions(mocked_kinto_client_icon_only))


### PR DESCRIPTION
[https://mozilla-hub.atlassian.net/browse/SPONS-162](https://mozilla-hub.atlassian.net/browse/SPONS-162)

**Summary**
This change prepares the quicksuggest2bq job for the new suggestion uuid field. (see [PR in MARS](https://github.com/mozilla-services/mars/pull/1210) for more details)

It also proposes a change to log new fields instead of erroring on them, I would be curious if reviewers welcome that change in behavior, or would prefer to leave it noisier with an error. Happy to revert this proposed change and just leave uuids.

**Other affected jobs?**
As far as I can tell this is the only job that currently consumes the kinto suggestions, are there other jobs I should be aware that may require updates for this?

**Merge and rollout timing?** 
This PR is not ready for immediate merge, we should merge it after changes are live in MARS to include new uuids in remote settings payload. Ideally this PR can be merged after new uuids are present in remote settings, but before this job runs. 

If that's not possible, we can consider a more cautious rollout without the need for specific timing, depending on what we decide above wrt to "log don't error" behavior. For example, we can merge just the "log dont error behavior" here, then roll out new uuids field, then merge the "consume new uuids" change here.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs

- [ ] Ensure the container image will be using permissions granted to [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/) responsibly.
