### PR TITLE
Move the etl jobs into their own subdirectory

### DIFF
--- a/jobs/webcompat-kb/tests/test_bugzilla.py
+++ b/jobs/webcompat-kb/tests/test_bugzilla.py
@@ -7,7 +7,7 @@ from typing import Any, Iterable, Mapping
 import pytest
 import bugdantic.bugzilla
 
-from webcompat_kb.bugzilla import (
+from webcompat_kb.etl.bugzilla import (
     Bug,
     BugHistoryChange,
     BugHistoryEntry,
@@ -1402,7 +1402,7 @@ def test_create_initial_history_removed_readded(history_updater):
     assert result == expected
 
 
-@patch("webcompat_kb.bugzilla.BugHistoryUpdater.bugzilla_fetch_history")
+@patch("webcompat_kb.etl.bugzilla.BugHistoryUpdater.bugzilla_fetch_history")
 def test_create_new_bugs_history(mock_bugzilla_fetch_history, history_updater):
     mock_bugzilla_fetch_history.return_value = (
         history_updater.bugzilla_to_history_entry(MISSING_KEYWORDS_HISTORY)
@@ -1457,7 +1457,7 @@ def test_missing_initial_add():
     assert empty_history.missing_initial_add()
 
 
-@patch("webcompat_kb.bugzilla.BugHistoryUpdater.bugzilla_fetch_history")
+@patch("webcompat_kb.etl.bugzilla.BugHistoryUpdater.bugzilla_fetch_history")
 def test_existing_bugs_history(mock_bugzilla_fetch_history, history_updater):
     mock_bugzilla_fetch_history.return_value = (
         history_updater.bugzilla_to_history_entry(MISSING_KEYWORDS_HISTORY)
@@ -1540,7 +1540,7 @@ def test_existing_bugs_history(mock_bugzilla_fetch_history, history_updater):
     assert result == expected
 
 
-@patch("webcompat_kb.bugzilla.BugHistoryUpdater.bugzilla_fetch_history")
+@patch("webcompat_kb.etl.bugzilla.BugHistoryUpdater.bugzilla_fetch_history")
 def test_existing_bugs_history_filter_updated(
     mock_bugzilla_fetch_history, history_updater
 ):

--- a/jobs/webcompat-kb/tests/test_patch.py
+++ b/jobs/webcompat-kb/tests/test_patch.py
@@ -2,7 +2,7 @@ import difflib
 
 import pytest
 
-from webcompat_kb.metric_changes import reverse_apply_diff
+from webcompat_kb.etl.metric_changes import reverse_apply_diff
 
 
 @pytest.mark.parametrize(

--- a/jobs/webcompat-kb/tests/test_update_schema.py
+++ b/jobs/webcompat-kb/tests/test_update_schema.py
@@ -1,4 +1,4 @@
-from webcompat_kb import update_schema
+from webcompat_kb.etl import update_schema
 from webcompat_kb.metrics.ranks import RankColumn
 from webcompat_kb.projectdata import (
     DatasetId,

--- a/jobs/webcompat-kb/webcompat_kb/commands/backfill_metric.py
+++ b/jobs/webcompat-kb/webcompat_kb/commands/backfill_metric.py
@@ -8,7 +8,7 @@ from ..base import Command
 from ..bqhelpers import BigQuery, DatasetId, get_client
 from ..config import Config
 from ..projectdata import Project
-from ..siterank import host_min_ranks_query
+from ..etl.siterank import host_min_ranks_query
 
 
 def backfill_host_min_ranks(

--- a/jobs/webcompat-kb/webcompat_kb/commands/bug_score_changes.py
+++ b/jobs/webcompat-kb/webcompat_kb/commands/bug_score_changes.py
@@ -8,7 +8,7 @@ from .. import projectdata
 from ..base import Command
 from ..bqhelpers import BigQuery, get_client
 from ..config import Config
-from ..metric_changes import (
+from ..etl.metric_changes import (
     BugChange,
     BugFieldChange,
     bugs_historic_states,

--- a/jobs/webcompat-kb/webcompat_kb/commands/checkdata.py
+++ b/jobs/webcompat-kb/webcompat_kb/commands/checkdata.py
@@ -9,7 +9,7 @@ from ..bqhelpers import get_client
 from ..config import Config
 from ..projectdata import lint_templates
 from ..commands.update_redash import render_dashboards
-from ..update_schema import SchemaCreator
+from ..etl.update_schema import SchemaCreator
 
 
 here = os.path.dirname(__file__)

--- a/jobs/webcompat-kb/webcompat_kb/commands/render.py
+++ b/jobs/webcompat-kb/webcompat_kb/commands/render.py
@@ -6,7 +6,7 @@ from .. import projectdata
 from ..base import DEFAULT_DATA_DIR
 from ..bqhelpers import SchemaId, get_client
 from ..config import Config
-from ..update_schema import render_schemas
+from ..etl.update_schema import render_schemas
 
 
 def main() -> None:

--- a/jobs/webcompat-kb/webcompat_kb/commands/update_staging_data.py
+++ b/jobs/webcompat-kb/webcompat_kb/commands/update_staging_data.py
@@ -7,7 +7,7 @@ from ..base import Command
 from ..bqhelpers import BigQuery, get_client
 from ..config import Config
 from ..projectdata import SchemaId, ReferenceType
-from ..update_schema import update_schema_if_needed
+from ..etl.update_schema import update_schema_if_needed
 
 
 class UpdateStagingData(Command):

--- a/jobs/webcompat-kb/webcompat_kb/commands/validate.py
+++ b/jobs/webcompat-kb/webcompat_kb/commands/validate.py
@@ -9,7 +9,7 @@ from .. import projectdata
 from ..base import Command
 from ..config import Config
 from ..bqhelpers import BigQuery, DatasetId, SchemaId, SchemaType, get_client
-from ..update_schema import render_schemas
+from ..etl.update_schema import render_schemas
 
 
 class Validate(Command):

--- a/jobs/webcompat-kb/webcompat_kb/etl/bugzilla.py
+++ b/jobs/webcompat-kb/webcompat_kb/etl/bugzilla.py
@@ -21,9 +21,9 @@ from datetime import datetime, timedelta
 import bugdantic
 from google.cloud import bigquery
 
-from .base import Context, EtlJob
-from .bqhelpers import BigQuery, TableSchema
-from .projectdata import Project
+from ..base import Context, EtlJob
+from ..bqhelpers import BigQuery, TableSchema
+from ..projectdata import Project
 
 
 class BugLoadError(Exception):

--- a/jobs/webcompat-kb/webcompat_kb/etl/chrome_use_counters.py
+++ b/jobs/webcompat-kb/webcompat_kb/etl/chrome_use_counters.py
@@ -6,10 +6,10 @@ from dataclasses import asdict, dataclass
 
 import pydantic
 
-from .base import Context, EtlJob, dataset_arg
-from .bqhelpers import BigQuery, TableSchema
-from .httphelpers import get_json
-from .projectdata import Project
+from ..base import Context, EtlJob, dataset_arg
+from ..bqhelpers import BigQuery, TableSchema
+from ..httphelpers import get_json
+from ..projectdata import Project
 
 
 class WebFeaturePopularity(pydantic.BaseModel):

--- a/jobs/webcompat-kb/webcompat_kb/etl/interop.py
+++ b/jobs/webcompat-kb/webcompat_kb/etl/interop.py
@@ -8,11 +8,11 @@ from typing import Mapping, MutableMapping, Optional
 from google.api_core.exceptions import NotFound
 from pydantic import BaseModel
 
-from .base import Context, EtlJob, dataset_arg
-from .bqhelpers import BigQuery, TableSchema
-from .github import GitHub, GitHubIssue
-from .httphelpers import Json
-from .projectdata import Project
+from ..base import Context, EtlJob, dataset_arg
+from ..bqhelpers import BigQuery, TableSchema
+from ..github import GitHub, GitHubIssue
+from ..httphelpers import Json
+from ..projectdata import Project
 
 
 class InteropRow(BaseModel):

--- a/jobs/webcompat-kb/webcompat_kb/etl/interventions.py
+++ b/jobs/webcompat-kb/webcompat_kb/etl/interventions.py
@@ -8,12 +8,12 @@ from google.api_core.exceptions import NotFound
 from pydantic import BaseModel, Field, model_validator
 from google.cloud import bigquery
 
-from .base import Context, EtlJob
-from .bqhelpers import BigQuery, TableSchema
-from .github import GitHub
-from .httphelpers import get_json
+from ..base import Context, EtlJob
+from ..bqhelpers import BigQuery, TableSchema
+from ..github import GitHub
+from ..httphelpers import get_json
 from .interop import repo_arg
-from .projectdata import Project
+from ..projectdata import Project
 
 
 class AlterHeader(BaseModel):

--- a/jobs/webcompat-kb/webcompat_kb/etl/metric.py
+++ b/jobs/webcompat-kb/webcompat_kb/etl/metric.py
@@ -1,9 +1,9 @@
 import logging
 from datetime import date
 
-from .base import Context, EtlJob
-from .bqhelpers import BigQuery
-from .projectdata import Project
+from ..base import Context, EtlJob
+from ..bqhelpers import BigQuery
+from ..projectdata import Project
 
 
 def update_metric_history(project: Project, client: BigQuery) -> None:

--- a/jobs/webcompat-kb/webcompat_kb/etl/metric_changes.py
+++ b/jobs/webcompat-kb/webcompat_kb/etl/metric_changes.py
@@ -9,10 +9,10 @@ from typing import Iterator, Mapping, Optional, Sequence, cast
 
 from google.cloud import bigquery
 
-from .base import Context, EtlJob
-from .bqhelpers import BigQuery, Json, TableSchema
+from ..base import Context, EtlJob
+from ..bqhelpers import BigQuery, Json, TableSchema
 from .bugzilla import parse_user_story
-from .projectdata import Project
+from ..projectdata import Project
 
 FIXED_STATES = {"RESOLVED", "VERIFIED"}
 MIN_CHANGE_DATE = datetime(2024, 1, 1, tzinfo=timezone.utc)

--- a/jobs/webcompat-kb/webcompat_kb/etl/siterank.py
+++ b/jobs/webcompat-kb/webcompat_kb/etl/siterank.py
@@ -8,10 +8,10 @@ from typing import Any, Optional, cast
 import httpx
 from google.cloud import bigquery
 
-from .base import Context, EtlJob
-from .bqhelpers import BigQuery, Json, TableSchema
-from .httphelpers import get_json
-from .projectdata import Project
+from ..base import Context, EtlJob
+from ..bqhelpers import BigQuery, Json, TableSchema
+from ..httphelpers import get_json
+from ..projectdata import Project
 
 
 @dataclass

--- a/jobs/webcompat-kb/webcompat_kb/etl/standards_positions.py
+++ b/jobs/webcompat-kb/webcompat_kb/etl/standards_positions.py
@@ -6,10 +6,10 @@ from urllib.parse import urlparse
 
 import pydantic
 
-from .base import Context, EtlJob, dataset_arg
-from .bqhelpers import BigQuery, TableSchema
-from .httphelpers import get_json
-from .projectdata import Project
+from ..base import Context, EtlJob, dataset_arg
+from ..bqhelpers import BigQuery, TableSchema
+from ..httphelpers import get_json
+from ..projectdata import Project
 
 
 class StandardsPosition(pydantic.BaseModel):

--- a/jobs/webcompat-kb/webcompat_kb/etl/update_schema.py
+++ b/jobs/webcompat-kb/webcompat_kb/etl/update_schema.py
@@ -11,23 +11,23 @@ from typing import Any, Callable, Iterable, Mapping, Optional, Sequence
 import jinja2
 from google.cloud import bigquery
 
-from . import metric_rescore
-from .base import ALL_JOBS, Context, EtlJob
-from .bqhelpers import (
+from .. import metric_rescore
+from ..base import ALL_JOBS, Context, EtlJob
+from ..bqhelpers import (
     BigQuery,
     DatasetId,
     SchemaId,
     SchemaType,
     TableSchema,
 )
-from .projectdata import (
+from ..projectdata import (
     Project,
     ReferenceType,
     SchemaTemplate,
     TableSchemaCreator,
     lint_templates,
 )
-from .treehash import hash_tree
+from ..treehash import hash_tree
 
 
 here = os.path.dirname(__file__)

--- a/jobs/webcompat-kb/webcompat_kb/etl/user_reports_aggregate.py
+++ b/jobs/webcompat-kb/webcompat_kb/etl/user_reports_aggregate.py
@@ -2,9 +2,9 @@ import logging
 
 from google.cloud import bigquery
 
-from .base import Context, EtlJob
-from .bqhelpers import BigQuery
-from .projectdata import Project
+from ..base import Context, EtlJob
+from ..bqhelpers import BigQuery
+from ..projectdata import Project
 
 
 def update_user_report_aggregate(project: Project, client: BigQuery) -> None:

--- a/jobs/webcompat-kb/webcompat_kb/etl/web_features.py
+++ b/jobs/webcompat-kb/webcompat_kb/etl/web_features.py
@@ -9,8 +9,8 @@ from google.cloud import bigquery
 from webfeatures import FeaturesFile
 from webfeatures.features import Feature, FeatureMoved, FeatureSplit
 
-from .base import Context, EtlJob, dataset_arg
-from .bqhelpers import BigQuery, Json
+from ..base import Context, EtlJob, dataset_arg
+from ..bqhelpers import BigQuery, Json
 
 
 def get_imported_releases(client: BigQuery) -> dict[str, datetime]:

--- a/jobs/webcompat-kb/webcompat_kb/main.py
+++ b/jobs/webcompat-kb/webcompat_kb/main.py
@@ -5,7 +5,7 @@ from typing import Iterable, Optional
 
 # These imports are required to populate ALL_JOBS
 # Unhappily the ordering here is significant
-from . import (
+from .etl import (
     update_schema,  # noqa: F401
     bugzilla,  # noqa: F401
     siterank,  # noqa: F401

--- a/jobs/webcompat-kb/webcompat_kb/metric_rescore.py
+++ b/jobs/webcompat-kb/webcompat_kb/metric_rescore.py
@@ -4,7 +4,7 @@ from typing import Mapping, Sequence
 
 from google.cloud import bigquery
 
-from . import metric_changes
+from .etl import metric_changes
 from .bqhelpers import (
     BigQuery,
     DatasetId,
@@ -14,7 +14,7 @@ from .bqhelpers import (
 )
 from .metrics import metrics, rescores
 from .metrics.rescores import Rescore
-from .metric_changes import ScoreChange
+from .etl.metric_changes import ScoreChange
 from .projectdata import Project
 
 


### PR DESCRIPTION
The base directory was a mixture of etl jobs and library functionality; moving the actual etl jobs into a subdirectory is a bit clearer.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs

- [ ] Ensure the container image will be using permissions granted to [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/) responsibly.
