### PR TITLE
Allow ETL jobs to return a bool indicating success

### DIFF
--- a/jobs/webcompat-kb/webcompat_kb/base.py
+++ b/jobs/webcompat-kb/webcompat_kb/base.py
@@ -160,5 +160,5 @@ class EtlJob(ABC):
     def default_dataset(self, context: Context) -> str: ...
 
     @abstractmethod
-    def main(self, context: Context) -> None:
+    def main(self, context: Context) -> Optional[bool]:
         pass

--- a/jobs/webcompat-kb/webcompat_kb/etl/autowebcompat.py
+++ b/jobs/webcompat-kb/webcompat_kb/etl/autowebcompat.py
@@ -332,13 +332,19 @@ class BigQueryService:
 
 def poll_pending(
     hackbot_client: Hackbot, run_uuids: list[UUID]
-) -> Mapping[UUID, RunDoc]:
+) -> tuple[Mapping[UUID, RunDoc], list[UUID]]:
     complete_runs = {}
+    failed = []
     for run_uuid in run_uuids:
-        run_data, complete = hackbot_client.poll_run(run_uuid)
-        if complete:
-            complete_runs[run_data.run_id] = run_data
-    return complete_runs
+        try:
+            run_data, complete = hackbot_client.poll_run(run_uuid)
+        except Exception as e:
+            logging.error(f"Checking pending run failed: {e}")
+            failed.append(run_uuid)
+        else:
+            if complete:
+                complete_runs[run_data.run_id] = run_data
+    return complete_runs, failed
 
 
 @dataclass
@@ -686,15 +692,16 @@ def run(
     check_pending: bool,
     updaters: Sequence[Updater],
     tasks: Sequence[type[HackbotTask]],
-) -> None:
+) -> bool:
     bq_service = BigQueryService(project, bq_client, bz_client)
     source_times = bq_service.get_source_times()
 
     if check_pending:
         pending_runs = bq_service.get_pending()
-        complete_runs = poll_pending(hackbot_client, pending_runs)
+        complete_runs, poll_failed = poll_pending(hackbot_client, pending_runs)
     else:
         complete_runs = {}
+        poll_failed = []
 
     complete_runs_scheduled = bq_service.get_scheduled_by_uuid(
         list(complete_runs.keys())
@@ -740,6 +747,8 @@ def run(
             )
         )
 
+    return False if poll_failed else True
+
 
 class AutowebcompatJob(EtlJob):
     name = "autowebcompat"
@@ -770,7 +779,7 @@ class AutowebcompatJob(EtlJob):
     def default_dataset(self, context: Context) -> str:
         return "autowebcompat"
 
-    def main(self, context: Context) -> None:
+    def main(self, context: Context) -> bool:
         bz_config = bugzilla.BugzillaConfig(
             "https://bugzilla.mozilla.org",
             context.args.bugzilla_api_key,
@@ -785,7 +794,7 @@ class AutowebcompatJob(EtlJob):
             )
         )
 
-        run(
+        return run(
             context.project,
             context.bq_client,
             bz_client,

--- a/jobs/webcompat-kb/webcompat_kb/main.py
+++ b/jobs/webcompat-kb/webcompat_kb/main.py
@@ -123,7 +123,9 @@ class EtlCommand(Command):
             )
             context.bq_client = bq_client
             try:
-                job.main(context)
+                success = job.main(context)
+                if success is not None and not success:
+                    failed.append(job_name)
             except Exception as e:
                 if args.pdb or args.fail_on_error:
                     raise


### PR DESCRIPTION
Use this to allow the job to continue if it partially failed, without having to raise an exception at the end.

Also use this for the autowebcompat job to handle failures to poll a pending run.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs

- [ ] Ensure the container image will be using permissions granted to [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/) responsibly.
