### PR TITLE
Add regex to look for a dataset.table when linting

### DIFF
--- a/jobs/webcompat-kb/webcompat_kb/projectdata.py
+++ b/jobs/webcompat-kb/webcompat_kb/projectdata.py
@@ -3,6 +3,7 @@ import enum
 import logging
 import os
 import pathlib
+import re
 import tomllib
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -658,7 +659,14 @@ def lint_templates(
             if project in template.template:
                 success = False
                 logging.error(f"Found project id in template {template.path}")
-            if dataset_templates.id.dataset in template.template:
+            # Only flag the dataset id when it's used as a table qualifier
+            # (e.g. `dataset.table`), not when the name happens to appear inside
+            # a string literal or column alias (e.g. a "[autowebcompat:...]"
+            # whiteboard token in a dataset also named "autowebcompat").
+            if re.search(
+                r"\b" + re.escape(dataset_templates.id.dataset) + r"\.",
+                template.template,
+            ):
                 success = False
                 logging.error(f"Found dataset id in template for {template.path}")
 


### PR DESCRIPTION
The `update-schema` job been failing because it detects dataset id in `autowebcompat:processed` flag as the whiteboard flags contain `autowebcompat` dataset name in them.

```
[2026-07-03, 17:46:59 UTC] {pod_manager.py:477} INFO - [base] ERROR:root:Found dataset id in template for /app/data/sql/autowebcompat/views/autowebcompat_site_reports
[2026-07-03, 17:46:59 UTC] {pod_manager.py:477} INFO - [base] ERROR:root:Template lint failed
```
Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs

- [ ] Ensure the container image will be using permissions granted to [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/) responsibly.
