### PR TITLE
Update CI templates for GHA guidelines

### DIFF
--- a/.github/job-workflow.template.yml
+++ b/.github/job-workflow.template.yml
@@ -5,6 +5,8 @@
 
 name: {{ job_name }}
 
+permissions: {}
+
 on:
   push:
     branches:

--- a/.github/workflows/job-ads-attribution-dap-collector.yml
+++ b/.github/workflows/job-ads-attribution-dap-collector.yml
@@ -5,6 +5,8 @@
 
 name: ads-attribution-dap-collector
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -20,9 +22,13 @@ on:
 jobs:
   build-job-ads-attribution-dap-collector:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Build the Docker image
         # yamllint disable
         run: |
@@ -41,7 +47,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -50,7 +56,7 @@ jobs:
           docker build jobs/ads-attribution-dap-collector -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/ads-attribution-dap-collector:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/ads-attribution-dap-collector:latest

--- a/.github/workflows/job-ads-incrementality-dap-collector.yml
+++ b/.github/workflows/job-ads-incrementality-dap-collector.yml
@@ -5,6 +5,8 @@
 
 name: ads-incrementality-dap-collector
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -20,9 +22,13 @@ on:
 jobs:
   build-job-ads-incrementality-dap-collector:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Build the Docker image
         # yamllint disable
         run: |
@@ -41,7 +47,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -50,7 +56,7 @@ jobs:
           docker build jobs/ads-incrementality-dap-collector -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/ads-incrementality-dap-collector:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/ads-incrementality-dap-collector:latest

--- a/.github/workflows/job-bq2sftp.yml
+++ b/.github/workflows/job-bq2sftp.yml
@@ -5,6 +5,8 @@
 
 name: bq2sftp
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -20,9 +22,13 @@ on:
 jobs:
   build-job-bq2sftp:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Build the Docker image
         # yamllint disable
         run: |
@@ -39,7 +45,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -48,7 +54,7 @@ jobs:
           docker build jobs/bq2sftp -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/bq2sftp:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/bq2sftp:latest

--- a/.github/workflows/job-broken-site-report-ml.yml
+++ b/.github/workflows/job-broken-site-report-ml.yml
@@ -5,6 +5,8 @@
 
 name: broken-site-report-ml
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -20,9 +22,13 @@ on:
 jobs:
   build-job-broken-site-report-ml:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Build the Docker image
         # yamllint disable
         run: |
@@ -41,7 +47,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -50,7 +56,7 @@ jobs:
           docker build jobs/broken-site-report-ml -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/broken-site-report-ml:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/broken-site-report-ml:latest

--- a/.github/workflows/job-client-regeneration.yml
+++ b/.github/workflows/job-client-regeneration.yml
@@ -5,6 +5,8 @@
 
 name: client-regeneration
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -20,9 +22,13 @@ on:
 jobs:
   build-job-client-regeneration:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Build the Docker image
         # yamllint disable
         run: |
@@ -41,7 +47,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -50,7 +56,7 @@ jobs:
           docker build jobs/client-regeneration -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/client-regeneration:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/client-regeneration:latest

--- a/.github/workflows/job-dap-collector-ppa-dev.yml
+++ b/.github/workflows/job-dap-collector-ppa-dev.yml
@@ -5,6 +5,8 @@
 
 name: dap-collector-ppa-dev
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -20,9 +22,13 @@ on:
 jobs:
   build-job-dap-collector-ppa-dev:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Build the Docker image
         # yamllint disable
         run: |
@@ -41,7 +47,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -50,7 +56,7 @@ jobs:
           docker build jobs/dap-collector-ppa-dev -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/dap-collector-ppa-dev:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/dap-collector-ppa-dev:latest

--- a/.github/workflows/job-dap-collector-ppa-prod.yml
+++ b/.github/workflows/job-dap-collector-ppa-prod.yml
@@ -5,6 +5,8 @@
 
 name: dap-collector-ppa-prod
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -20,9 +22,13 @@ on:
 jobs:
   build-job-dap-collector-ppa-prod:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Build the Docker image
         # yamllint disable
         run: |
@@ -41,7 +47,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -50,7 +56,7 @@ jobs:
           docker build jobs/dap-collector-ppa-prod -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/dap-collector-ppa-prod:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/dap-collector-ppa-prod:latest

--- a/.github/workflows/job-dap-collector.yml
+++ b/.github/workflows/job-dap-collector.yml
@@ -5,6 +5,8 @@
 
 name: dap-collector
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -20,9 +22,13 @@ on:
 jobs:
   build-job-dap-collector:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Build the Docker image
         # yamllint disable
         run: |
@@ -39,7 +45,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -48,7 +54,7 @@ jobs:
           docker build jobs/dap-collector -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/dap-collector:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/dap-collector:latest

--- a/.github/workflows/job-desktop-mobile-mau-2020.yml
+++ b/.github/workflows/job-desktop-mobile-mau-2020.yml
@@ -5,6 +5,8 @@
 
 name: desktop-mobile-mau-2020
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -20,9 +22,13 @@ on:
 jobs:
   build-job-desktop-mobile-mau-2020:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Build the Docker image
         # yamllint disable
         run: |

--- a/.github/workflows/job-eam-integrations.yml
+++ b/.github/workflows/job-eam-integrations.yml
@@ -5,6 +5,8 @@
 
 name: eam-integrations
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -20,9 +22,13 @@ on:
 jobs:
   build-job-eam-integrations:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Build the Docker image
         # yamllint disable
         run: |
@@ -39,7 +45,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -48,7 +54,7 @@ jobs:
           docker build jobs/eam-integrations -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/eam-integrations:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/eam-integrations:latest

--- a/.github/workflows/job-example_job.yml
+++ b/.github/workflows/job-example_job.yml
@@ -5,6 +5,8 @@
 
 name: example_job
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -20,9 +22,13 @@ on:
 jobs:
   build-job-example_job:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Build the Docker image
         # yamllint disable
         run: |
@@ -39,7 +45,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -48,7 +54,7 @@ jobs:
           docker build jobs/example_job -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/example_job:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/example_job:latest

--- a/.github/workflows/job-experiments-monitoring-data-export.yml
+++ b/.github/workflows/job-experiments-monitoring-data-export.yml
@@ -5,6 +5,8 @@
 
 name: experiments-monitoring-data-export
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -20,9 +22,13 @@ on:
 jobs:
   build-job-experiments-monitoring-data-export:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Build the Docker image
         # yamllint disable
         run: |
@@ -39,7 +45,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -48,7 +54,7 @@ jobs:
           docker build jobs/experiments-monitoring-data-export -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/experiments-monitoring-data-export:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/experiments-monitoring-data-export:latest

--- a/.github/workflows/job-extensions.yml
+++ b/.github/workflows/job-extensions.yml
@@ -5,6 +5,8 @@
 
 name: extensions
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -20,9 +22,13 @@ on:
 jobs:
   build-job-extensions:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Build the Docker image
         # yamllint disable
         run: |
@@ -41,7 +47,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -50,7 +56,7 @@ jobs:
           docker build jobs/extensions -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/extensions:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/extensions:latest

--- a/.github/workflows/job-fxci-taskcluster-export.yml
+++ b/.github/workflows/job-fxci-taskcluster-export.yml
@@ -5,6 +5,8 @@
 
 name: fxci-taskcluster-export
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -20,9 +22,13 @@ on:
 jobs:
   build-job-fxci-taskcluster-export:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Build the Docker image
         # yamllint disable
         run: |
@@ -41,7 +47,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -50,7 +56,7 @@ jobs:
           docker build jobs/fxci-taskcluster-export -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/fxci-taskcluster-export:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/fxci-taskcluster-export:latest

--- a/.github/workflows/job-influxdb-to-bigquery.yml
+++ b/.github/workflows/job-influxdb-to-bigquery.yml
@@ -5,6 +5,8 @@
 
 name: influxdb-to-bigquery
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -20,9 +22,13 @@ on:
 jobs:
   build-job-influxdb-to-bigquery:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Build the Docker image
         # yamllint disable
         run: |
@@ -39,7 +45,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -48,7 +54,7 @@ jobs:
           docker build jobs/influxdb-to-bigquery -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/influxdb-to-bigquery:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/influxdb-to-bigquery:latest

--- a/.github/workflows/job-kpi-forecasting.yml
+++ b/.github/workflows/job-kpi-forecasting.yml
@@ -5,6 +5,8 @@
 
 name: kpi-forecasting
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -20,9 +22,13 @@ on:
 jobs:
   build-job-kpi-forecasting:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Build the Docker image
         # yamllint disable
         run: |
@@ -41,7 +47,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -50,7 +56,7 @@ jobs:
           docker build jobs/kpi-forecasting -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/kpi-forecasting:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/kpi-forecasting:latest

--- a/.github/workflows/job-looker-utils.yml
+++ b/.github/workflows/job-looker-utils.yml
@@ -5,6 +5,8 @@
 
 name: looker-utils
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -20,9 +22,13 @@ on:
 jobs:
   build-job-looker-utils:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Build the Docker image
         # yamllint disable
         run: |
@@ -39,7 +45,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -48,7 +54,7 @@ jobs:
           docker build jobs/looker-utils -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/looker-utils:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/looker-utils:latest

--- a/.github/workflows/job-mozaggregator2bq.yml
+++ b/.github/workflows/job-mozaggregator2bq.yml
@@ -5,6 +5,8 @@
 
 name: mozaggregator2bq
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -20,9 +22,13 @@ on:
 jobs:
   build-job-mozaggregator2bq:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Build the Docker image
         # yamllint disable
         run: |
@@ -39,7 +45,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -48,7 +54,7 @@ jobs:
           docker build jobs/mozaggregator2bq -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/mozaggregator2bq:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/mozaggregator2bq:latest

--- a/.github/workflows/job-play-store-export.yml
+++ b/.github/workflows/job-play-store-export.yml
@@ -5,6 +5,8 @@
 
 name: play-store-export
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -22,7 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Build the Docker image
         # yamllint disable
         run: |
@@ -43,7 +47,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -52,7 +56,7 @@ jobs:
           docker build jobs/play-store-export -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/play-store-export:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/play-store-export:latest

--- a/.github/workflows/job-quicksuggest2bq.yml
+++ b/.github/workflows/job-quicksuggest2bq.yml
@@ -5,6 +5,8 @@
 
 name: quicksuggest2bq
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -20,9 +22,13 @@ on:
 jobs:
   build-job-quicksuggest2bq:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Build the Docker image
         # yamllint disable
         run: |
@@ -43,7 +49,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -52,7 +58,7 @@ jobs:
           docker build jobs/quicksuggest2bq -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/quicksuggest2bq:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/quicksuggest2bq:latest

--- a/.github/workflows/job-release_scraping.yml
+++ b/.github/workflows/job-release_scraping.yml
@@ -5,6 +5,8 @@
 
 name: release_scraping
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -20,9 +22,13 @@ on:
 jobs:
   build-job-release-scraping:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Build the Docker image
         # yamllint disable
         run: |
@@ -41,7 +47,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -55,7 +61,7 @@ jobs:
           docker build jobs/release_scraping -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/release_scraping:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/release_scraping:latest

--- a/.github/workflows/job-search-alert.yml
+++ b/.github/workflows/job-search-alert.yml
@@ -5,6 +5,8 @@
 
 name: search-alert
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -20,9 +22,13 @@ on:
 jobs:
   build-job-search-alert:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Build the Docker image
         # yamllint disable
         run: |
@@ -39,7 +45,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -48,7 +54,7 @@ jobs:
           docker build jobs/search-alert -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/search-alert:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/search-alert:latest

--- a/.github/workflows/job-search-term-data-validation-v2.yml
+++ b/.github/workflows/job-search-term-data-validation-v2.yml
@@ -5,6 +5,8 @@
 
 name: search-term-data-validation-v2
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -20,9 +22,13 @@ on:
 jobs:
   build-job-search-term-data-validation-v2:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Build the Docker image
         # yamllint disable
         run: |
@@ -41,7 +47,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -50,7 +56,7 @@ jobs:
           docker build jobs/search-term-data-validation-v2 -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/search-term-data-validation-v2:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/search-term-data-validation-v2:latest

--- a/.github/workflows/job-webcompat-kb.yml
+++ b/.github/workflows/job-webcompat-kb.yml
@@ -5,6 +5,8 @@
 
 name: webcompat-kb
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -20,9 +22,13 @@ on:
 jobs:
   build-job-webcompat-kb:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Build the Docker image
         # yamllint disable
         run: |
@@ -45,7 +51,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -54,7 +60,7 @@ jobs:
           docker build jobs/webcompat-kb -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/webcompat-kb:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/webcompat-kb:latest

--- a/docker_etl/ci_config.py
+++ b/docker_etl/ci_config.py
@@ -57,34 +57,12 @@ def update_config(dry_run: bool = False) -> str:
         # Extract job name from path (e.g., jobs/bq2sftp/ci_job.yaml -> bq2sftp)
         job_name = job_config_path.parent.name
 
-        # Read the job config and remove path filter steps
         job_config_text = job_config_path.read_text()
-
-        # Remove the path filter step from job config
-        lines = job_config_text.split('\n')
-        filtered_lines = []
-        skip_until_next_step = False
-
-        for line in lines:
-            if '- name: Check if job files changed' in line:
-                skip_until_next_step = True
-                continue
-            if skip_until_next_step:
-                if line.strip().startswith('- name:'):
-                    skip_until_next_step = False
-                else:
-                    continue
-            # Remove 'if: steps.changes.outputs.job' lines
-            if "if: steps.changes.outputs.job == 'true'" in line:
-                continue
-            filtered_lines.append(line)
-
-        clean_job_config = '\n'.join(filtered_lines)
 
         # Generate workflow file
         workflow_text = workflow_template.render(
             job_name=job_name,
-            job_config=clean_job_config,
+            job_config=job_config_text,
         )
 
         workflow_filename = f"job-{job_name}.yml"

--- a/jobs/ads-attribution-dap-collector/ci_job.yaml
+++ b/jobs/ads-attribution-dap-collector/ci_job.yaml
@@ -1,23 +1,18 @@
   build-job-ads-attribution-dap-collector:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Check if job files changed
-        id: changes
-        uses: dorny/paths-filter@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          filters: |
-            job:
-              - 'jobs/ads-attribution-dap-collector/**'
+          persist-credentials: false
       - name: Build the Docker image
-        if: steps.changes.outputs.job == 'true'
         # yamllint disable
         run: |
           docker build jobs/ads-attribution-dap-collector -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/ads-attribution-dap-collector:latest
         # yamllint enable
       - name: Test Code
-        if: steps.changes.outputs.job == 'true'
         run: docker run us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/ads-attribution-dap-collector:latest python3 -m pytest
 
   deploy-to-gar-ads-attribution-dap-collector:
@@ -30,7 +25,7 @@
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -39,7 +34,7 @@
           docker build jobs/ads-attribution-dap-collector -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/ads-attribution-dap-collector:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/ads-attribution-dap-collector:latest

--- a/jobs/ads-incrementality-dap-collector/ci_job.yaml
+++ b/jobs/ads-incrementality-dap-collector/ci_job.yaml
@@ -1,23 +1,18 @@
   build-job-ads-incrementality-dap-collector:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Check if job files changed
-        id: changes
-        uses: dorny/paths-filter@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          filters: |
-            job:
-              - 'jobs/ads-incrementality-dap-collector/**'
+          persist-credentials: false
       - name: Build the Docker image
-        if: steps.changes.outputs.job == 'true'
         # yamllint disable
         run: |
           docker build jobs/ads-incrementality-dap-collector -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/ads-incrementality-dap-collector:latest
         # yamllint enable
       - name: Test Code
-        if: steps.changes.outputs.job == 'true'
         run: docker run us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/ads-incrementality-dap-collector:latest python3 -m pytest
 
   deploy-to-gar-ads-incrementality-dap-collector:
@@ -30,7 +25,7 @@
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -39,7 +34,7 @@
           docker build jobs/ads-incrementality-dap-collector -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/ads-incrementality-dap-collector:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/ads-incrementality-dap-collector:latest

--- a/jobs/bq2sftp/ci_job.yaml
+++ b/jobs/bq2sftp/ci_job.yaml
@@ -1,17 +1,13 @@
   build-job-bq2sftp:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Check if job files changed
-        id: changes
-        uses: dorny/paths-filter@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          filters: |
-            job:
-              - 'jobs/bq2sftp/**'
+          persist-credentials: false
       - name: Build the Docker image
-        if: steps.changes.outputs.job == 'true'
         # yamllint disable
         run: |
           docker build jobs/bq2sftp -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/bq2sftp:latest
@@ -27,7 +23,7 @@
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -36,7 +32,7 @@
           docker build jobs/bq2sftp -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/bq2sftp:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/bq2sftp:latest

--- a/jobs/broken-site-report-ml/ci_job.yaml
+++ b/jobs/broken-site-report-ml/ci_job.yaml
@@ -1,23 +1,18 @@
   build-job-broken-site-report-ml:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Check if job files changed
-        id: changes
-        uses: dorny/paths-filter@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          filters: |
-            job:
-              - 'jobs/broken-site-report-ml/**'
+          persist-credentials: false
       - name: Build the Docker image
-        if: steps.changes.outputs.job == 'true'
         # yamllint disable
         run: |
           docker build jobs/broken-site-report-ml -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/broken-site-report-ml:latest
         # yamllint enable
       - name: Test Code
-        if: steps.changes.outputs.job == 'true'
         run: docker run us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/broken-site-report-ml:latest pytest --flake8 --black
 
   deploy-to-gar-broken-site-report-ml:
@@ -30,7 +25,7 @@
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -39,7 +34,7 @@
           docker build jobs/broken-site-report-ml -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/broken-site-report-ml:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/broken-site-report-ml:latest

--- a/jobs/client-regeneration/ci_job.yaml
+++ b/jobs/client-regeneration/ci_job.yaml
@@ -1,23 +1,18 @@
   build-job-client-regeneration:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Check if job files changed
-        id: changes
-        uses: dorny/paths-filter@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          filters: |
-            job:
-              - 'jobs/client-regeneration/**'
+          persist-credentials: false
       - name: Build the Docker image
-        if: steps.changes.outputs.job == 'true'
         # yamllint disable
         run: |
           docker build jobs/client-regeneration -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/client-regeneration:latest
         # yamllint enable
       - name: Test Code
-        if: steps.changes.outputs.job == 'true'
         run: docker run us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/client-regeneration:latest pytest --flake8 --black
 
   deploy-to-gar-client-regeneration:
@@ -30,7 +25,7 @@
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -39,7 +34,7 @@
           docker build jobs/client-regeneration -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/client-regeneration:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/client-regeneration:latest

--- a/jobs/dap-collector-ppa-dev/ci_job.yaml
+++ b/jobs/dap-collector-ppa-dev/ci_job.yaml
@@ -1,23 +1,18 @@
   build-job-dap-collector-ppa-dev:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Check if job files changed
-        id: changes
-        uses: dorny/paths-filter@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          filters: |
-            job:
-              - 'jobs/dap-collector-ppa-dev/**'
+          persist-credentials: false
       - name: Build the Docker image
-        if: steps.changes.outputs.job == 'true'
         # yamllint disable
         run: |
           docker build jobs/dap-collector-ppa-dev -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/dap-collector-ppa-dev:latest
         # yamllint enable
       - name: Test Code
-        if: steps.changes.outputs.job == 'true'
         run: docker run us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/dap-collector-ppa-dev:latest python3 -m pytest
 
   deploy-to-gar-dap-collector-ppa-dev:
@@ -30,7 +25,7 @@
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -39,7 +34,7 @@
           docker build jobs/dap-collector-ppa-dev -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/dap-collector-ppa-dev:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/dap-collector-ppa-dev:latest

--- a/jobs/dap-collector-ppa-prod/ci_job.yaml
+++ b/jobs/dap-collector-ppa-prod/ci_job.yaml
@@ -1,23 +1,18 @@
   build-job-dap-collector-ppa-prod:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Check if job files changed
-        id: changes
-        uses: dorny/paths-filter@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          filters: |
-            job:
-              - 'jobs/dap-collector-ppa-prod/**'
+          persist-credentials: false
       - name: Build the Docker image
-        if: steps.changes.outputs.job == 'true'
         # yamllint disable
         run: |
           docker build jobs/dap-collector-ppa-prod -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/dap-collector-ppa-prod:latest
         # yamllint enable
       - name: Test Code
-        if: steps.changes.outputs.job == 'true'
         run: docker run us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/dap-collector-ppa-prod:latest python3 -m pytest
 
   deploy-to-gar-dap-collector-ppa-prod:
@@ -30,7 +25,7 @@
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -39,7 +34,7 @@
           docker build jobs/dap-collector-ppa-prod -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/dap-collector-ppa-prod:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/dap-collector-ppa-prod:latest

--- a/jobs/dap-collector/ci_job.yaml
+++ b/jobs/dap-collector/ci_job.yaml
@@ -1,17 +1,13 @@
   build-job-dap-collector:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Check if job files changed
-        id: changes
-        uses: dorny/paths-filter@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          filters: |
-            job:
-              - 'jobs/dap-collector/**'
+          persist-credentials: false
       - name: Build the Docker image
-        if: steps.changes.outputs.job == 'true'
         # yamllint disable
         run: |
           docker build jobs/dap-collector -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/dap-collector:latest
@@ -27,7 +23,7 @@
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -36,7 +32,7 @@
           docker build jobs/dap-collector -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/dap-collector:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/dap-collector:latest

--- a/jobs/desktop-mobile-mau-2020/ci_job.yaml
+++ b/jobs/desktop-mobile-mau-2020/ci_job.yaml
@@ -1,21 +1,16 @@
   build-job-desktop-mobile-mau-2020:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Check if job files changed
-        id: changes
-        uses: dorny/paths-filter@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          filters: |
-            job:
-              - 'jobs/desktop-mobile-mau-2020/**'
+          persist-credentials: false
       - name: Build the Docker image
-        if: steps.changes.outputs.job == 'true'
         # yamllint disable
         run: |
           docker build jobs/desktop-mobile-mau-2020 -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/desktop-mobile-mau-2020:latest
         # yamllint enable
       - name: Test Code
-        if: steps.changes.outputs.job == 'true'
         run: docker run us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/desktop-mobile-mau-2020:latest pytest --flake8 --black

--- a/jobs/eam-integrations/ci_job.yaml
+++ b/jobs/eam-integrations/ci_job.yaml
@@ -1,17 +1,13 @@
   build-job-eam-integrations:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Check if job files changed
-        id: changes
-        uses: dorny/paths-filter@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          filters: |
-            job:
-              - 'jobs/eam-integrations/**'
+          persist-credentials: false
       - name: Build the Docker image
-        if: steps.changes.outputs.job == 'true'
         # yamllint disable
         run: |
           docker build jobs/eam-integrations -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/eam-integrations:latest
@@ -27,7 +23,7 @@
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -36,7 +32,7 @@
           docker build jobs/eam-integrations -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/eam-integrations:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/eam-integrations:latest

--- a/jobs/example_job/ci_job.yaml
+++ b/jobs/example_job/ci_job.yaml
@@ -1,17 +1,13 @@
   build-job-example_job:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Check if job files changed
-        id: changes
-        uses: dorny/paths-filter@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          filters: |
-            job:
-              - 'jobs/example_job/**'
+          persist-credentials: false
       - name: Build the Docker image
-        if: steps.changes.outputs.job == 'true'
         # yamllint disable
         run: |
           docker build jobs/example_job -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/example_job:latest
@@ -27,7 +23,7 @@
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -36,7 +32,7 @@
           docker build jobs/example_job -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/example_job:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/example_job:latest

--- a/jobs/experiments-monitoring-data-export/ci_job.yaml
+++ b/jobs/experiments-monitoring-data-export/ci_job.yaml
@@ -1,17 +1,13 @@
   build-job-experiments-monitoring-data-export:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Check if job files changed
-        id: changes
-        uses: dorny/paths-filter@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          filters: |
-            job:
-              - 'jobs/experiments-monitoring-data-export/**'
+          persist-credentials: false
       - name: Build the Docker image
-        if: steps.changes.outputs.job == 'true'
         # yamllint disable
         run: |
           docker build jobs/experiments-monitoring-data-export -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/experiments-monitoring-data-export:latest
@@ -27,7 +23,7 @@
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -36,7 +32,7 @@
           docker build jobs/experiments-monitoring-data-export -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/experiments-monitoring-data-export:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/experiments-monitoring-data-export:latest

--- a/jobs/extensions/ci_job.yaml
+++ b/jobs/extensions/ci_job.yaml
@@ -1,23 +1,18 @@
   build-job-extensions:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Check if job files changed
-        id: changes
-        uses: dorny/paths-filter@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          filters: |
-            job:
-              - 'jobs/extensions/**'
+          persist-credentials: false
       - name: Build the Docker image
-        if: steps.changes.outputs.job == 'true'
         # yamllint disable
         run: |
           docker build jobs/extensions -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/extensions:latest
         # yamllint enable
       - name: Test Code
-        if: steps.changes.outputs.job == 'true'
         run: docker run us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/extensions:latest pytest --flake8 --black
 
   deploy-to-gar-extensions:
@@ -30,7 +25,7 @@
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -39,7 +34,7 @@
           docker build jobs/extensions -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/extensions:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/extensions:latest

--- a/jobs/fxci-taskcluster-export/ci_job.yaml
+++ b/jobs/fxci-taskcluster-export/ci_job.yaml
@@ -1,23 +1,18 @@
   build-job-fxci-taskcluster-export:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Check if job files changed
-        id: changes
-        uses: dorny/paths-filter@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          filters: |
-            job:
-              - 'jobs/fxci-taskcluster-export/**'
+          persist-credentials: false
       - name: Build the Docker image
-        if: steps.changes.outputs.job == 'true'
         # yamllint disable
         run: |
           docker build jobs/fxci-taskcluster-export -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/fxci-taskcluster-export:latest
         # yamllint enable
       - name: Test Code
-        if: steps.changes.outputs.job == 'true'
         run: docker run us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/fxci-taskcluster-export:latest pytest -vv
 
   deploy-to-gar-fxci-taskcluster-export:
@@ -30,7 +25,7 @@
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -39,7 +34,7 @@
           docker build jobs/fxci-taskcluster-export -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/fxci-taskcluster-export:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/fxci-taskcluster-export:latest

--- a/jobs/influxdb-to-bigquery/ci_job.yaml
+++ b/jobs/influxdb-to-bigquery/ci_job.yaml
@@ -1,17 +1,13 @@
   build-job-influxdb-to-bigquery:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Check if job files changed
-        id: changes
-        uses: dorny/paths-filter@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          filters: |
-            job:
-              - 'jobs/influxdb-to-bigquery/**'
+          persist-credentials: false
       - name: Build the Docker image
-        if: steps.changes.outputs.job == 'true'
         # yamllint disable
         run: |
           docker build jobs/influxdb-to-bigquery -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/influxdb-to-bigquery:latest
@@ -27,7 +23,7 @@
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -36,7 +32,7 @@
           docker build jobs/influxdb-to-bigquery -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/influxdb-to-bigquery:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/influxdb-to-bigquery:latest

--- a/jobs/kpi-forecasting/ci_job.yaml
+++ b/jobs/kpi-forecasting/ci_job.yaml
@@ -1,23 +1,18 @@
   build-job-kpi-forecasting:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Check if job files changed
-        id: changes
-        uses: dorny/paths-filter@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          filters: |
-            job:
-              - 'jobs/kpi-forecasting/**'
+          persist-credentials: false
       - name: Build the Docker image
-        if: steps.changes.outputs.job == 'true'
         # yamllint disable
         run: |
           docker build jobs/kpi-forecasting -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/kpi-forecasting:latest
         # yamllint enable
       - name: Test Code
-        if: steps.changes.outputs.job == 'true'
         run: docker run us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/kpi-forecasting:latest pytest --ruff --ruff-format
 
   deploy-to-gar-kpi-forecasting:
@@ -30,7 +25,7 @@
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -39,7 +34,7 @@
           docker build jobs/kpi-forecasting -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/kpi-forecasting:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/kpi-forecasting:latest

--- a/jobs/looker-utils/ci_job.yaml
+++ b/jobs/looker-utils/ci_job.yaml
@@ -1,17 +1,13 @@
   build-job-looker-utils:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Check if job files changed
-        id: changes
-        uses: dorny/paths-filter@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          filters: |
-            job:
-              - 'jobs/looker-utils/**'
+          persist-credentials: false
       - name: Build the Docker image
-        if: steps.changes.outputs.job == 'true'
         # yamllint disable
         run: |
           docker build jobs/looker-utils -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/looker-utils:latest
@@ -27,7 +23,7 @@
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -36,7 +32,7 @@
           docker build jobs/looker-utils -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/looker-utils:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/looker-utils:latest

--- a/jobs/mozaggregator2bq/ci_job.yaml
+++ b/jobs/mozaggregator2bq/ci_job.yaml
@@ -1,17 +1,13 @@
   build-job-mozaggregator2bq:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Check if job files changed
-        id: changes
-        uses: dorny/paths-filter@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          filters: |
-            job:
-              - 'jobs/mozaggregator2bq/**'
+          persist-credentials: false
       - name: Build the Docker image
-        if: steps.changes.outputs.job == 'true'
         # yamllint disable
         run: |
           docker build jobs/mozaggregator2bq -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/mozaggregator2bq:latest
@@ -27,7 +23,7 @@
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -36,7 +32,7 @@
           docker build jobs/mozaggregator2bq -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/mozaggregator2bq:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/mozaggregator2bq:latest

--- a/jobs/play-store-export/ci_job.yaml
+++ b/jobs/play-store-export/ci_job.yaml
@@ -2,25 +2,17 @@
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Check if job files changed
-        id: changes
-        uses: dorny/paths-filter@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          filters: |
-            job:
-              - 'jobs/play-store-export/**'
+          persist-credentials: false
       - name: Build the Docker image
-        if: steps.changes.outputs.job == 'true'
         # yamllint disable
         run: |
           docker build jobs/play-store-export -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/play-store-export:latest
         # yamllint enable
       - name: Test Code
-        if: steps.changes.outputs.job == 'true'
         run: docker run us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/play-store-export:latest make test
       - name: Lint Code
-        if: steps.changes.outputs.job == 'true'
         run: docker run us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/play-store-export:latest make lint
 
   deploy-to-gar-play-store-export:
@@ -33,7 +25,7 @@
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -42,7 +34,7 @@
           docker build jobs/play-store-export -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/play-store-export:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/play-store-export:latest

--- a/jobs/quicksuggest2bq/ci_job.yaml
+++ b/jobs/quicksuggest2bq/ci_job.yaml
@@ -1,26 +1,20 @@
   build-job-quicksuggest2bq:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Check if job files changed
-        id: changes
-        uses: dorny/paths-filter@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          filters: |
-            job:
-              - 'jobs/quicksuggest2bq/**'
+          persist-credentials: false
       - name: Build the Docker image
-        if: steps.changes.outputs.job == 'true'
         # yamllint disable
         run: |
           docker build jobs/quicksuggest2bq -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/quicksuggest2bq:latest
         # yamllint enable
       - name: Test Code
-        if: steps.changes.outputs.job == 'true'
         run: docker run us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/quicksuggest2bq:latest pytest --flake8 --black
       - name: Lint Code
-        if: steps.changes.outputs.job == 'true'
         run: docker run us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/quicksuggest2bq:latest flake8
 
   deploy-to-gar-quicksuggest2bq:
@@ -33,7 +27,7 @@
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -42,7 +36,7 @@
           docker build jobs/quicksuggest2bq -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/quicksuggest2bq:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/quicksuggest2bq:latest

--- a/jobs/release_scraping/ci_job.yaml
+++ b/jobs/release_scraping/ci_job.yaml
@@ -1,23 +1,18 @@
   build-job-release-scraping:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Check if job files changed
-        id: changes
-        uses: dorny/paths-filter@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          filters: |
-            job:
-              - 'jobs/release_scraping/**'
+          persist-credentials: false
       - name: Build the Docker image
-        if: steps.changes.outputs.job == 'true'
         # yamllint disable
         run: |
           docker build jobs/release_scraping -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/release_scraping:latest
         # yamllint enable
       - name: Test Code
-        if: steps.changes.outputs.job == 'true'
         run: docker run us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/release_scraping:latest pytest --flake8 --black
 
   deploy-to-gar-release-scraping:
@@ -30,7 +25,7 @@
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -44,7 +39,7 @@
           docker build jobs/release_scraping -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/release_scraping:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/release_scraping:latest

--- a/jobs/search-alert/ci_job.yaml
+++ b/jobs/search-alert/ci_job.yaml
@@ -1,17 +1,13 @@
   build-job-search-alert:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Check if job files changed
-        id: changes
-        uses: dorny/paths-filter@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          filters: |
-            job:
-              - 'jobs/search-alert/**'
+          persist-credentials: false
       - name: Build the Docker image
-        if: steps.changes.outputs.job == 'true'
         # yamllint disable
         run: |
           docker build jobs/search-alert -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/search-alert:latest
@@ -27,7 +23,7 @@
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -36,7 +32,7 @@
           docker build jobs/search-alert -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/search-alert:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/search-alert:latest

--- a/jobs/search-term-data-validation-v2/ci_job.yaml
+++ b/jobs/search-term-data-validation-v2/ci_job.yaml
@@ -1,23 +1,18 @@
   build-job-search-term-data-validation-v2:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Check if job files changed
-        id: changes
-        uses: dorny/paths-filter@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          filters: |
-            job:
-              - 'jobs/search-term-data-validation-v2/**'
+          persist-credentials: false
       - name: Build the Docker image
-        if: steps.changes.outputs.job == 'true'
         # yamllint disable
         run: |
           docker build jobs/search-term-data-validation-v2 -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/search-term-data-validation-v2:latest
         # yamllint enable
       - name: Test Code
-        if: steps.changes.outputs.job == 'true'
         run: docker run us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/search-term-data-validation-v2:latest pytest
 
   deploy-to-gar-search-term-data-validation-v2:
@@ -30,7 +25,7 @@
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -39,7 +34,7 @@
           docker build jobs/search-term-data-validation-v2 -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/search-term-data-validation-v2:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/search-term-data-validation-v2:latest

--- a/jobs/webcompat-kb/ci_job.yaml
+++ b/jobs/webcompat-kb/ci_job.yaml
@@ -1,29 +1,22 @@
   build-job-webcompat-kb:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Check if job files changed
-        id: changes
-        uses: dorny/paths-filter@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          filters: |
-            job:
-              - 'jobs/webcompat-kb/**'
+          persist-credentials: false
       - name: Build the Docker image
-        if: steps.changes.outputs.job == 'true'
         # yamllint disable
         run: |
           docker build jobs/webcompat-kb -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/webcompat-kb:latest
         # yamllint enable
       - name: ty
-        if: steps.changes.outputs.job == 'true'
         run: docker run us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/webcompat-kb:latest ty check --python=/usr/local/bin/python webcompat_kb
       - name: Mypy
-        if: steps.changes.outputs.job == 'true'
         run: docker run us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/webcompat-kb:latest mypy webcompat_kb
       - name: Test Code
-        if: steps.changes.outputs.job == 'true'
         run: docker run us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/webcompat-kb:latest pytest --ruff --ruff-format
 
   deploy-to-gar-webcompat-kb:
@@ -36,7 +29,7 @@
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -45,7 +38,7 @@
           docker build jobs/webcompat-kb -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/webcompat-kb:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/webcompat-kb:latest

--- a/templates/default/ci_job.template.yaml
+++ b/templates/default/ci_job.template.yaml
@@ -1,8 +1,12 @@
   build-job-{{ job_name }}:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Build the Docker image
         # yamllint disable
         run: |
@@ -19,7 +23,7 @@
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image
@@ -28,7 +32,7 @@
           docker build jobs/{{ job_name }} -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/{{ job_name }}:latest
         # yamllint enable
       - name: Push Docker image latest to GAR
-        uses: mozilla/deploy-actions/docker-push@v6.6.3
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/{{ job_name }}:latest

--- a/templates/python/ci_job.template.yaml
+++ b/templates/python/ci_job.template.yaml
@@ -1,46 +1,41 @@
   build-job-{{ job_name }}:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Check if job files changed
-        id: changes
-        uses: dorny/paths-filter@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          filters: |
-            job:
-              - 'jobs/{{ job_name }}/**'
+          persist-credentials: false
 
       - name: Build Docker image
-        if: steps.changes.outputs.job == 'true' || github.ref == 'refs/heads/main' || contains(github.event.head_commit.message, '[run-tests]')
         run: docker build jobs/{{ job_name }}/ -t app:build
 
       - name: Test Code
-        if: steps.changes.outputs.job == 'true' || github.ref == 'refs/heads/main' || contains(github.event.head_commit.message, '[run-tests]')
         run: docker run app:build pytest --flake8 --black
 
-  push-job-{{ job_name }}:
+  deploy-to-gar-{{ job_name }}:
+    name: Deploy {{ job_name }} to GAR
     runs-on: ubuntu-latest
-    needs: build-job-{{ job_name }}
+    needs: [build-job-{{ job_name }}]
     if: github.ref == 'refs/heads/main'
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          credentials_json: {{ '${{ secrets.GCP_CREDENTIALS }}' }}
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-
-      - name: Configure Docker for GCR
-        run: gcloud auth configure-docker
-
-      - name: Build Docker image
-        run: docker build jobs/{{ job_name }}/ -t gcr.io/${{ '${{ secrets.GCP_PROJECT }}' }}/{{ job_name }}_docker_etl:latest
-
-      - name: Push to GCR
-        run: docker push gcr.io/${{ '${{ secrets.GCP_PROJECT }}' }}/{{ job_name }}_docker_etl:latest
+          persist-credentials: false
+      - name: Build the Docker image
+        # yamllint disable
+        run: |
+          docker build jobs/{{ job_name }} -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/{{ job_name }}:latest
+        # yamllint enable
+      - name: Push Docker image latest to GAR
+        uses: mozilla/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
+        with:
+          project_id: moz-fx-data-artifacts-prod
+          image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/{{ job_name }}:latest
+          workload_identity_pool_project_number: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
+          service_account_name: docker-etl


### PR DESCRIPTION
Switch the python template to deploy to GAR, pin actions to hashes, explicitly set permissions for steps, and remove the `dorny/paths-filter` usage because the generator script was deleting it anyway

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs

- [ ] Ensure the container image will be using permissions granted to [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/) responsibly.
