### PR TITLE
[SPONS-231] Fix quicksuggest2bq job for uuid2suggestion_id rename

### DIFF
--- a/jobs/quicksuggest2bq/quicksuggest2bq/main.py
+++ b/jobs/quicksuggest2bq/quicksuggest2bq/main.py
@@ -29,17 +29,15 @@ class FullKeyword:
 class KintoSuggestion:
     """Class that holds information about a Suggestion returned by Kinto."""
 
-    # By being explicit about the fields we expect and not just storing the
-    # raw JSON, we control exactly what gets written to BigQuery. New fields
-    # added to the Remote Settings payload are ignored by `from_dict` (and
-    # logged) so that additive schema changes don't break the job. To start
-    # ingesting a new field, add it here and to the BigQuery schema in
-    # `store_suggestions`.
+    # Declaring fields explicitly controls exactly what gets written to
+    # BigQuery. `from_dict` drops added payload fields (logged) but lets a
+    # missing required field raise. To ingest a new field, add it here and to
+    # the BigQuery schema in `store_suggestions`.
     advertiser: str
     iab_category: str
     icon: str
     id: int
-    uuid: str
+    suggestion_id: str
     keywords: List[str]
     title: str
     url: str
@@ -158,7 +156,7 @@ def store_suggestions(
             bigquery.SchemaField("icon", "STRING"),
             bigquery.SchemaField("impression_url", "STRING"),
             bigquery.SchemaField("id", "INTEGER"),
-            bigquery.SchemaField("uuid", "STRING"),
+            bigquery.SchemaField("suggestion_id", "STRING"),
             bigquery.SchemaField("keywords", "STRING", "REPEATED"),
             bigquery.SchemaField(
                 "full_keywords",

--- a/jobs/quicksuggest2bq/tests/test_main.py
+++ b/jobs/quicksuggest2bq/tests/test_main.py
@@ -10,7 +10,7 @@ SERP_CATEGORIES = [1, 2]
 
 SAMPLE_SUGGESTION = {
     "id": 2802,
-    "uuid": "8d3a1b2c-4e5f-6a7b-8c9d-0e1f2a3b4c5d",
+    "suggestion_id": "8d3a1b2c-4e5f-6a7b-8c9d-0e1f2a3b4c5d",
     "url": "https://www.example.com",
     "click_url": "https://example.com/click",
     "impression_url": "https://example.com/impression",
@@ -30,7 +30,7 @@ SAMPLE_SUGGESTION = {
 
 SAMPLE_WIKIPEDIA_SUGGESTION = {
     "id": 0,
-    "uuid": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+    "suggestion_id": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
     "url": "https://www.wikipedia.org",
     "iab_category": "5 - Education",
     "icon": "4072021",
@@ -156,11 +156,13 @@ class TestMain:
         assert suggestions[0].score == SAMPLE_SUGGESTION["score"]
         assert suggestions[1].score == SAMPLE_WIKIPEDIA_SUGGESTION["score"]
 
-    def test_suggestion_uuid(self, mocked_kinto_client):
+    def test_suggestion_id(self, mocked_kinto_client):
         suggestions = list(download_suggestions(mocked_kinto_client))
         assert len(suggestions) == 2
-        assert suggestions[0].uuid == SAMPLE_SUGGESTION["uuid"]
-        assert suggestions[1].uuid == SAMPLE_WIKIPEDIA_SUGGESTION["uuid"]
+        assert suggestions[0].suggestion_id == SAMPLE_SUGGESTION["suggestion_id"]
+        assert (
+            suggestions[1].suggestion_id == SAMPLE_WIKIPEDIA_SUGGESTION["suggestion_id"]
+        )
 
     def test_icon_records_not_downloaded(self, mocked_kinto_client_icon_only):
         suggestions = list(download_suggestions(mocked_kinto_client_icon_only))


### PR DESCRIPTION
This job has been broken for a little while we just didn't get notified before: 

https://bugzilla.mozilla.org/show_bug.cgi?id=2047223
Sister ticket in the SPONS project: https://mozilla-hub.atlassian.net/browse/SPONS-231

I'll look into consuming the notifications for this job directly as we continue to iterate in the suggest remote settings payload.

I'll keep an eye on this and make sure it succeeds on next run, and will follow up with more fixes if any additional issues come up.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs

- [ ] Ensure the container image will be using permissions granted to [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/) responsibly.
