### PR TITLE
Bug 2047223 - quicksuggest2bq: tolerate suggestions without a suggestion_id

### DIFF
--- a/jobs/quicksuggest2bq/quicksuggest2bq/main.py
+++ b/jobs/quicksuggest2bq/quicksuggest2bq/main.py
@@ -37,11 +37,16 @@ class KintoSuggestion:
     iab_category: str
     icon: str
     id: int
-    suggestion_id: str
     keywords: List[str]
     title: str
     url: str
     full_keywords: List[FullKeyword]
+
+    # `suggestion_id` is missing from Remote Settings records that predate it and
+    # are no longer being republished (e.g. `sponsored-suggestions-us-tablet`,
+    # last modified in May 2025). Those suggestions are ingested with a NULL
+    # `suggestion_id` rather than failing the job.
+    suggestion_id: Optional[str] = None
 
     # `click_url` and `impression_url` are both optional, they're currently only
     # used by suggestions from adMarketplace. Mozilla's in-house Wikipedia suggestions
@@ -112,7 +117,25 @@ def download_suggestions(client: kinto_http.Client) -> Iterator[KintoSuggestion]
         # object contains a list of keywords. Load the suggestions into
         # KintoSuggestion dataclass instances to discard all fields which we
         # don't care about here.
-        for suggestion_data in response.json():
+        attachment = response.json()
+
+        without_suggestion_id = sum(
+            1
+            for suggestion_data in attachment
+            if "suggestion_id" not in suggestion_data
+        )
+        if without_suggestion_id:
+            # Warn rather than fail: a whole attachment missing `suggestion_id`
+            # is expected for records that are no longer republished, but it
+            # would also be the symptom of another upstream field rename.
+            logging.warning(
+                "%s of %s suggestions in record '%s' have no 'suggestion_id'.",
+                without_suggestion_id,
+                len(attachment),
+                record["id"],
+            )
+
+        for suggestion_data in attachment:
             suggestion: Dict[str, Any] = {
                 **suggestion_data,
                 "full_keywords": [

--- a/jobs/quicksuggest2bq/tests/test_main.py
+++ b/jobs/quicksuggest2bq/tests/test_main.py
@@ -82,6 +82,38 @@ def mocked_kinto_client(mocker: MockerFixture):
 
 
 @pytest.fixture()
+def mocked_kinto_client_without_suggestion_id(mocker: MockerFixture):
+    """Serve an attachment from a record that predates `suggestion_id`."""
+    session = mocker.MagicMock()
+
+    mock_server_info = {"capabilities": {"attachments": {"base_url": "discarded"}}}
+
+    mock_records = [
+        {"type": "amp", "id": 2802, "attachment": {"location": "discarded/again"}},
+    ]
+
+    class MockResponse:
+        status_code = 200
+
+        def json(self) -> List[Dict]:
+            return [
+                {
+                    key: value
+                    for key, value in SAMPLE_SUGGESTION.items()
+                    if key not in ("suggestion_id", "serp_categories")
+                }
+            ]
+
+    client = kinto_http.Client(session=session, bucket="mybucket")
+
+    mocker.patch.object(client, "server_info", return_value=mock_server_info)
+    mocker.patch.object(client, "get_records", return_value=mock_records)
+    mocker.patch("requests.Session.get", return_value=MockResponse())
+
+    yield client
+
+
+@pytest.fixture()
 def mocked_kinto_client_icon_only(mocker: MockerFixture):
     session = mocker.MagicMock()
 
@@ -163,6 +195,19 @@ class TestMain:
         assert (
             suggestions[1].suggestion_id == SAMPLE_WIKIPEDIA_SUGGESTION["suggestion_id"]
         )
+
+    def test_suggestion_id_missing(
+        self, mocked_kinto_client_without_suggestion_id, caplog
+    ):
+        # Records that are no longer republished predate `suggestion_id`, they
+        # are ingested with a NULL value instead of failing the job.
+        suggestions = list(
+            download_suggestions(mocked_kinto_client_without_suggestion_id)
+        )
+        assert len(suggestions) == 1
+        assert suggestions[0].suggestion_id is None
+        assert suggestions[0].id == SAMPLE_SUGGESTION["id"]
+        assert "1 of 1 suggestions in record '2802'" in caplog.text
 
     def test_icon_records_not_downloaded(self, mocked_kinto_client_icon_only):
         suggestions = list(download_suggestions(mocked_kinto_client_icon_only))


### PR DESCRIPTION
The job has failed daily since 2026-06-11. The uuid -> suggestion_id rename was handled in #554, but three Remote Settings records in quicksuggest-amp predate the field entirely and are no longer republished: sponsored-suggestions-us-tablet (last modified 2025-05-12) and sponsored-suggestions-pl-{desktop,phone} (2025-05-29). Because suggestion_id was a required dataclass field, those 1,273 of 33,182 suggestions raised "TypeError: __init__() missing 1 required positional argument: 'suggestion_id'" and failed the run.

Make suggestion_id optional so those rows load with a NULL value, which the BigQuery schema already allows. Log one warning per attachment that is missing the field, so a future upstream rename stays visible in the logs without emitting a line per suggestion.

The dead records are the underlying problem and should be dropped from the collection by the suggest team; this only keeps the job from failing in the meantime.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs

- [ ] Ensure the container image will be using permissions granted to [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/) responsibly.
