### PR TITLE
Fix 529 Overloaded error

### DIFF
--- a/jobs/webcompat-kb/webcompat_kb/etl/autowebcompat.py
+++ b/jobs/webcompat-kb/webcompat_kb/etl/autowebcompat.py
@@ -20,7 +20,7 @@ import filetype
 import httpx
 from bugdantic import bugzilla, userstory
 from google.cloud import bigquery
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from ..base import Context, EtlJob
 from ..bqhelpers import BigQuery
@@ -724,11 +724,56 @@ class ReproTask(HackbotTask):
                 run_id: NewBugInfo.model_validate(scheduled_run.request_data)
                 for run_id, (scheduled_run, _) in self.completed_runs.items()
             }
-            run_outputs = {
-                run_id: ReproSummary.model_validate(run_doc.summary.model_dump())
-                for run_id, (_, run_doc) in self.completed_runs.items()
-                if run_doc.summary is not None
-            }
+            run_outputs = {}
+            overload_markers = {"529", "overloaded", "at capacity"}
+            for run_id, (scheduled_run, run_doc) in list(self.completed_runs.items()):
+                if run_doc.summary is None:
+                    continue
+                try:
+                    run_outputs[run_id] = ReproSummary.model_validate(
+                        run_doc.summary.model_dump()
+                    )
+                except ValidationError:
+                    error = run_doc.summary.error or ""
+                    if not any(
+                        marker in error.lower() for marker in overload_markers
+                    ):
+                        raise
+                    # The agent hit an overload error (e.g. 529) and never
+                    # produced a valid result. Reschedule a fresh hackbot run and
+                    # drop this errored run from the update path so it isn't marked
+                    # as a repro-failure.
+                    logging.info(
+                        "Run %s failed with an overload error, rescheduling: %s",
+                        run_id,
+                        error,
+                    )
+                    bug_info = NewBugInfo.model_validate(scheduled_run.request_data)
+                    source_time = bug_info.creation_time
+                    run_ref = self.hackbot_client.create_run(
+                        self.get_request_data(
+                            ScheduleRequest(
+                                source_key=scheduled_run.source_key,
+                                run_key=scheduled_run.run_key,
+                                source_time=source_time,
+                                request_data=bug_info,
+                            )
+                        )
+                    )
+                    self.scheduled[scheduled_run.source_key].append(
+                        ScheduledRun(
+                            run_id=run_ref.run_id,
+                            agent=scheduled_run.agent,
+                            task_name=scheduled_run.task_name,
+                            source_key=scheduled_run.source_key,
+                            run_key=scheduled_run.run_key,
+                            source_time=source_time,
+                            requested_at=datetime.now(),
+                            request_data=scheduled_run.request_data,
+                            extra_data=scheduled_run.extra_data,
+                        )
+                    )
+                    del self.completed_runs[run_id]
 
             for uuid, output in run_outputs.items():
                 bug_info = run_inputs[uuid]


### PR DESCRIPTION
There have been a few runs that've failed because of 529 overloaded error https://hackbot.moz.tools/runs/35f4e7b9-50cc-484d-b253-f153929161fc

So that cause the job to fail with a validation error

```
 [2026-07-22, 16:04:33 UTC] {pod_manager.py:477} INFO - [base] ERROR:root:1 validation error for ReproSummary                                                                               
  [2026-07-22, 16:04:33 UTC] {pod_manager.py:477} INFO - [base] findings.num_turns                                                                                                                                              
  [2026-07-22, 16:04:33 UTC] {pod_manager.py:477} INFO - [base]   Field required [type=missing, input_value={'traceback': 'NoneType: None\n'}, input_type=dict]                                                                 
  [2026-07-22, 16:04:33 UTC] {pod_manager.py:477} INFO - [base]     For further information visit https://errors.pydantic.dev/2.13/v/missing                                                                                    
  [2026-07-22, 16:04:34 UTC] {pod_manager.py:496} INFO - [base] ERROR:root:1 jobs failed: autowebcompat  
```
I've added a quick fix that is rescheduling these kinds of runs and doesn't record the failure in bugzilla, but wanted to test it once more when this error happens again, so adding a draft PR. 

Also maybe `populate_updates` is the wrong place for this and it should go after take_completed_runs:

```
task_runner.take_completed_runs(complete_runs_remaining)

        scheduled = task_runner.create_new()
```

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs

- [ ] Ensure the container image will be using permissions granted to [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/) responsibly.
