### PR TITLE
Allow override of site rank in webcompat score using user-story data

### DIFF
--- a/jobs/webcompat-kb/data/sql/webcompat_knowledge_base/routines/WEBCOMPAT_METRIC_SCORE_SITE_RANK_MODIFIER/routine.sql
+++ b/jobs/webcompat-kb/data/sql/webcompat_knowledge_base/routines/WEBCOMPAT_METRIC_SCORE_SITE_RANK_MODIFIER/routine.sql
@@ -1,36 +1,69 @@
-CREATE OR REPLACE FUNCTION `{{ ref(name) }}`(url STRING, crux_yyyymm INT64) RETURNS NUMERIC AS (
+CREATE OR REPLACE FUNCTION `{{ ref(name) }}`(url STRING, crux_yyyymm INT64, user_story JSON) RETURNS NUMERIC AS (
   (
+    WITH
+      host_ranks AS (
+        SELECT
+          MIN(global_rank) AS global_rank,
+          MIN(core_rank) AS core_rank,
+          MIN(india_rank) AS india_rank,
+          MIN(brazil_rank) AS brazil_rank,
+          MIN(indonesia_rank) AS indonesia_rank,
+          MIN(mexico_rank) AS mexico_rank,
+          MIN(italy_rank) AS italy_rank,
+          MIN(spain_rank) AS spain_rank,
+          MIN(netherlands_rank) AS netherlands_rank,
+          MIN(local_rank) AS local_rank
+        FROM
+          `{{ ref ('crux_imported.host_min_ranks') }}` AS host_ranks
+        WHERE
+          host_ranks.yyyymm = crux_yyyymm AND `{{ ref('WEBCOMPAT_HOST') }}`(host_ranks.host) = `{{ ref('WEBCOMPAT_HOST') }}`(url)
+      ),
+      site_rank_override AS (
+        SELECT `{{ ref('EXTRACT_ARRAY') }}`(user_story, "$.site-rank-override") AS ranks
+      )
     SELECT
       CAST(CASE
-        WHEN MIN(host_ranks.global_rank) <= 1000 THEN 15
         WHEN
-          MIN(host_ranks.core_rank) <= 1000 OR
-          MIN(host_ranks.india_rank) <= 1000 OR
-          MIN(host_ranks.brazil_rank) <= 1000 OR
-          MIN(host_ranks.indonesia_rank) <= 1000 OR
-          MIN(host_ranks.mexico_rank) <= 1000 OR
-          MIN(host_ranks.italy_rank) <= 1000 OR
-          MIN(host_ranks.spain_rank) <= 1000 OR
-          MIN(host_ranks.netherlands_rank) <= 1000
+          host_ranks.global_rank <= 1000 OR
+          "global-1k" IN UNNEST(site_rank_override.ranks)
+          THEN 15
+        WHEN
+          host_ranks.core_rank <= 1000 OR
+          host_ranks.india_rank <= 1000 OR
+          host_ranks.brazil_rank <= 1000 OR
+          host_ranks.indonesia_rank <= 1000 OR
+          host_ranks.mexico_rank <= 1000 OR
+          host_ranks.italy_rank <= 1000 OR
+          host_ranks.spain_rank <= 1000 OR
+          host_ranks.netherlands_rank <= 1000 OR
+          "core-1k" IN UNNEST(site_rank_override.ranks)
           THEN 10
-        WHEN MIN(host_ranks.global_rank) <= 10000 THEN 7.5
-        WHEN MIN(host_ranks.local_rank) <= 1000 THEN 5
         WHEN
-          MIN(host_ranks.core_rank) <= 10000 OR
-          MIN(host_ranks.india_rank) <= 10000 OR
-          MIN(host_ranks.brazil_rank) <= 10000 OR
-          MIN(host_ranks.indonesia_rank) <= 10000 OR
-          MIN(host_ranks.mexico_rank) <= 10000 OR
-          MIN(host_ranks.italy_rank) <= 10000 OR
-          MIN(host_ranks.spain_rank) <= 10000 OR
-          MIN(host_ranks.netherlands_rank) <= 10000
+          host_ranks.global_rank <= 10000 OR
+          "global-10k" IN UNNEST(site_rank_override.ranks)
+          THEN 7.5
+        WHEN
+          host_ranks.local_rank <= 1000 OR
+          "local-1k" IN UNNEST(site_rank_override.ranks)
           THEN 5
-        WHEN MIN(host_ranks.local_rank) <= 10000 THEN 2.5
+        WHEN
+          host_ranks.core_rank <= 10000 OR
+          host_ranks.india_rank <= 10000 OR
+          host_ranks.brazil_rank <= 10000 OR
+          host_ranks.indonesia_rank <= 10000 OR
+          host_ranks.mexico_rank <= 10000 OR
+          host_ranks.italy_rank <= 10000 OR
+          host_ranks.spain_rank <= 10000 OR
+          host_ranks.netherlands_rank <= 10000 OR
+          "core-10k" IN UNNEST(site_rank_override.ranks)
+          THEN 5
+        WHEN
+          host_ranks.local_rank <= 10000 OR
+          "local-10k" IN UNNEST(site_rank_override.ranks)
+          THEN 2.5
         ELSE 1
       END AS NUMERIC)
     FROM
-      `{{ ref ('crux_imported.host_min_ranks') }}` AS host_ranks
-    WHERE
-      host_ranks.yyyymm = crux_yyyymm AND `{{ ref('WEBCOMPAT_HOST') }}`(host_ranks.host) = `{{ ref('WEBCOMPAT_HOST') }}`(url)
+      host_ranks, site_rank_override
   )
 );

--- a/jobs/webcompat-kb/data/sql/webcompat_knowledge_base/views/scored_site_reports/view.sql
+++ b/jobs/webcompat-kb/data/sql/webcompat_knowledge_base/views/scored_site_reports/view.sql
@@ -62,10 +62,8 @@ These could be inlined, but it's slightly easier to read if they're computed in 
 computed_scores AS (
   SELECT
     number,
-    `{{ ref('WEBCOMPAT_METRIC_SCORE_NO_SITE_RANK') }}`(keywords,
-      user_story) AS triage_score_no_rank,
-    `{{ ref('WEBCOMPAT_METRIC_SCORE_SITE_RANK_MODIFIER') }}`(url,
-      `{{ ref('WEBCOMPAT_METRIC_YYYYMM') }}`()) AS site_rank_score
+    `{{ ref('WEBCOMPAT_METRIC_SCORE_NO_SITE_RANK') }}`(keywords, user_story) AS triage_score_no_rank,
+    `{{ ref('WEBCOMPAT_METRIC_SCORE_SITE_RANK_MODIFIER') }}`(url, `{{ ref('WEBCOMPAT_METRIC_YYYYMM') }}`(), user_story) AS site_rank_score
   FROM
     `{{ ref('site_reports') }}` AS site_reports
 ),

--- a/jobs/webcompat-kb/webcompat_kb/etl/metric_changes.py
+++ b/jobs/webcompat-kb/webcompat_kb/etl/metric_changes.py
@@ -381,7 +381,7 @@ SELECT number,
        url,
        keywords,
        user_story,
-       CAST(`{score_no_rank}`(keywords, user_story) * `{rank_modifier}`(url, `{rank_yyyymm}`()) AS NUMERIC) as score
+       CAST(`{score_no_rank}`(keywords, user_story) * `{rank_modifier}`(url, `{rank_yyyymm}`(), user_story) AS NUMERIC) as score
 FROM `{tmp_table.name}`
 """
         bugs_with_webcompat_states = set()


### PR DESCRIPTION
This is useful for cases where we think the domain rank isn't representative of the real impact of the problem e.g. for code that is deployed on many different domains or subdomains.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs

- [ ] Ensure the container image will be using permissions granted to [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/) responsibly.
