### PR TITLE
Refactor WEBCOMPAT_METRIC_SCORE to not use a WITH statement

### DIFF
--- a/jobs/webcompat-kb/data/sql/webcompat_knowledge_base/routines/WEBCOMPAT_METRIC_SCORE_SITE_RANK_MODIFIER/routine.sql
+++ b/jobs/webcompat-kb/data/sql/webcompat_knowledge_base/routines/WEBCOMPAT_METRIC_SCORE_SITE_RANK_MODIFIER/routine.sql
@@ -1,26 +1,5 @@
 CREATE OR REPLACE FUNCTION `{{ ref(name) }}`(url STRING, crux_yyyymm INT64, user_story JSON) RETURNS NUMERIC AS (
   (
-    WITH
-      host_ranks AS (
-        SELECT
-          MIN(global_rank) AS global_rank,
-          MIN(core_rank) AS core_rank,
-          MIN(india_rank) AS india_rank,
-          MIN(brazil_rank) AS brazil_rank,
-          MIN(indonesia_rank) AS indonesia_rank,
-          MIN(mexico_rank) AS mexico_rank,
-          MIN(italy_rank) AS italy_rank,
-          MIN(spain_rank) AS spain_rank,
-          MIN(netherlands_rank) AS netherlands_rank,
-          MIN(local_rank) AS local_rank
-        FROM
-          `{{ ref ('crux_imported.host_min_ranks') }}` AS host_ranks
-        WHERE
-          host_ranks.yyyymm = crux_yyyymm AND `{{ ref('WEBCOMPAT_HOST') }}`(host_ranks.host) = `{{ ref('WEBCOMPAT_HOST') }}`(url)
-      ),
-      site_rank_override AS (
-        SELECT `{{ ref('EXTRACT_ARRAY') }}`(user_story, "$.site-rank-override") AS ranks
-      )
     SELECT
       CAST(CASE
         WHEN
@@ -64,6 +43,25 @@ CREATE OR REPLACE FUNCTION `{{ ref(name) }}`(url STRING, crux_yyyymm INT64, user
         ELSE 1
       END AS NUMERIC)
     FROM
-      host_ranks, site_rank_override
+      (
+        SELECT
+          MIN(global_rank) AS global_rank,
+          MIN(core_rank) AS core_rank,
+          MIN(india_rank) AS india_rank,
+          MIN(brazil_rank) AS brazil_rank,
+          MIN(indonesia_rank) AS indonesia_rank,
+          MIN(mexico_rank) AS mexico_rank,
+          MIN(italy_rank) AS italy_rank,
+          MIN(spain_rank) AS spain_rank,
+          MIN(netherlands_rank) AS netherlands_rank,
+          MIN(local_rank) AS local_rank
+        FROM
+          `{{ ref ('crux_imported.host_min_ranks') }}` AS host_ranks
+        WHERE
+          host_ranks.yyyymm = crux_yyyymm AND `{{ ref('WEBCOMPAT_HOST') }}`(host_ranks.host) = `{{ ref('WEBCOMPAT_HOST') }}`(url)
+      ) AS host_ranks,
+      (
+        SELECT `{{ ref('EXTRACT_ARRAY') }}`(user_story, "$.site-rank-override") AS ranks
+      ) AS site_rank_override
   )
 );

--- a/jobs/webcompat-kb/data/sql/webcompat_knowledge_base/views/scored_site_reports_before_202507291148/view.sql
+++ b/jobs/webcompat-kb/data/sql/webcompat_knowledge_base/views/scored_site_reports_before_202507291148/view.sql
@@ -66,7 +66,7 @@ WITH
     `{{ ref('WEBCOMPAT_METRIC_SCORE_NO_SITE_RANK') }}`(keywords,
       user_story) AS triage_score_no_rank,
     `{{ ref('WEBCOMPAT_METRIC_SCORE_SITE_RANK_MODIFIER') }}`(url,
-      `{{ ref('WEBCOMPAT_METRIC_YYYYMM_before_202507291148') }}`()) AS site_rank_score
+      `{{ ref('WEBCOMPAT_METRIC_YYYYMM_before_202507291148') }}`(), PARSE_JSON("{}")) AS site_rank_score
   FROM
     `{{ ref('site_reports') }}` AS site_reports),
   site_report_scores AS (


### PR DESCRIPTION
This avoids the correlated subquery error that was preventing imports.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs

- [ ] Ensure the container image will be using permissions granted to [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/) responsibly.
