### PR TITLE
Fix  "HTTP/2 406 Not Acceptable" error when adding diagnosis comment with curl in backticks

### DIFF
--- a/jobs/webcompat-kb/tests/test_autowebcompat.py
+++ b/jobs/webcompat-kb/tests/test_autowebcompat.py
@@ -1,4 +1,5 @@
 import base64
+import html
 import json
 from collections import defaultdict
 from collections.abc import Iterable, Mapping
@@ -398,8 +399,12 @@ def test_diagnosis_bugzilla_update() -> None:
     assert updates.bug.whiteboard is None
 
     assert updates.bug.comment is not None
-    assert cast(str, result["root_cause"]) in updates.bug.comment.body
-    assert cast(str, result["evidence"]) in updates.bug.comment.body
+
+    def expected(value: str) -> str:
+        return html.escape(autowebcompat.sanitize_bugzilla_comment(value))
+
+    assert expected(cast(str, result["root_cause"])) in updates.bug.comment.body
+    assert expected(cast(str, result["evidence"])) in updates.bug.comment.body
 
     assert len(updates.add_attachments) == 1
     attachment = updates.add_attachments[0]

--- a/jobs/webcompat-kb/webcompat_kb/etl/autowebcompat.py
+++ b/jobs/webcompat-kb/webcompat_kb/etl/autowebcompat.py
@@ -1265,6 +1265,14 @@ class DiagnosisTask(HackbotTask):
                         ]
                         if result.evidence:
                             comment_parts += ["", "Evidence:", "", result.evidence]
+
+                        footer = (
+                            "If you'd like to provide feedback on this comment, please use the 👍 or 👎 "
+                            "reaction."
+                        )
+
+                        comment_parts += ["", "---", "", footer]
+
                         bug_update.bug.comment = bugzilla.Comment(
                             body=html.escape(
                                 sanitize_bugzilla_comment("\n".join(comment_parts))

--- a/jobs/webcompat-kb/webcompat_kb/etl/autowebcompat.py
+++ b/jobs/webcompat-kb/webcompat_kb/etl/autowebcompat.py
@@ -1265,14 +1265,6 @@ class DiagnosisTask(HackbotTask):
                         ]
                         if result.evidence:
                             comment_parts += ["", "Evidence:", "", result.evidence]
-
-                        footer = (
-                            "If you'd like to provide feedback on this comment, please use the 👍 or 👎 "
-                            "reaction."
-                        )
-
-                        comment_parts += ["", "---", "", footer]
-
                         bug_update.bug.comment = bugzilla.Comment(
                             body=html.escape(
                                 sanitize_bugzilla_comment("\n".join(comment_parts))

--- a/jobs/webcompat-kb/webcompat_kb/etl/autowebcompat.py
+++ b/jobs/webcompat-kb/webcompat_kb/etl/autowebcompat.py
@@ -3,6 +3,7 @@ import html
 import itertools
 import logging
 import os
+import re
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, MutableMapping, Sequence
@@ -680,6 +681,11 @@ def format_user_story_value(value: str | list[str]) -> str:
     return value
 
 
+def sanitize_bugzilla_comment(text: str) -> str:
+    """Unwrap backtick-quoted curl commands in agent-generated comment text."""
+    return re.sub(r"`(curl\b[^`\n]*)`", r"\1", text)
+
+
 def update_whiteboard(
     bug: bugzilla.Bug, bug_update: BugUpdate, require_tokens: list[str]
 ) -> None:
@@ -1260,7 +1266,9 @@ class DiagnosisTask(HackbotTask):
                         if result.evidence:
                             comment_parts += ["", "Evidence:", "", result.evidence]
                         bug_update.bug.comment = bugzilla.Comment(
-                            body="\n".join(comment_parts)
+                            body=html.escape(
+                                sanitize_bugzilla_comment("\n".join(comment_parts))
+                            )
                         )
 
                         if result.testcase_url:


### PR DESCRIPTION
Got 406 error when submitting a comment with curl in backticks for a comment like https://bugzilla.mozilla.org/show_bug.cgi?id=1913899#c6:

So stripping just the backticks for curl seem to work. Also added html escape for html elements, like `<iframe>`.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs

- [ ] Ensure the container image will be using permissions granted to [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/) responsibly.
