### PR TITLE
feat(highwind): write experiment and run level errors to BigQuery

### DIFF
--- a/jobs/highwind/README.md
+++ b/jobs/highwind/README.md
@@ -43,13 +43,21 @@ than defaulted.
 | --- | --- |
 | `moz-fx-data-experiments.highwind_poc.highwind_statistics_v1` | (slug, metric, window, comparison) |
 | `moz-fx-data-experiments.highwind_poc.highwind_sufficient_stats_v1` | (slug, metric, window, branch) |
+| `moz-fx-data-experiments.highwind_poc.highwind_logs_v1` | log record |
 | `gs://mozanalysis/highwind/<slug>.json` | experiment, the seam Experimenter reads |
 
-All three come from one computation, which is why they are one job rather than three. Both tables are
+All four come from one computation, which is why they are one job rather than four. Every table is
 partitioned on `as_of_date` and clustered on `slug`, and a run replaces its own date's partition
 rather than appending to it, so a retry produces the same table as the first run instead of doubling
 it. An object is named for its experiment with the slug's hyphens as underscores, so
 `new-tab-example-151` is written to `new_tab_example_151.json`.
+
+A cell that failed is already queryable, since the results grid is written whole and every cell
+carries a state and an error. The log table is for the failures that have no cell to carry them: an
+experiment that failed before producing any, a recipe the run refused to analyse, and the run-level
+account of what it consumed and what looked wrong. It is written in a `finally`, so a run that died
+partway records why, and its columns are the ones Jetstream's own BigQuery log handler writes, so
+that adopting that handler here later is a swap rather than a rewrite of whatever reads this.
 
 The cohort of enrolled units each run materializes is an intermediate rather than an output. It goes
 to a table of its own in `moz-fx-data-experiments.highwind_poc`, named per run so two runs of one
@@ -126,7 +134,7 @@ PyPI package of the same version pins a pandas that conflicts with the one this 
 Python package is copied out of that image; scipy, the one dependency it lacks, is declared in
 `requirements.txt`. The base image is `python:3.11-slim` to match the frozen tree.
 
-The job declares both table schemas itself, in `output_writing.py`, and passes them explicitly on
+The job declares its table schemas itself, in `output_writing.py`, and passes them explicitly on
 every load. Schema inference is off deliberately: a cell in the `error` or `not_started` state
 carries no interval, so an inferred schema would vary with the day's mix of states.
 

--- a/jobs/highwind/highwind/analysis.py
+++ b/jobs/highwind/highwind/analysis.py
@@ -17,7 +17,8 @@ Desktop experiments only, guardrail metrics only, full recompute every run. Each
 deliberate limit of the proof of concept and is noted where it bites.
 """
 
-import traceback
+import contextlib
+import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from google.cloud import storage  # type: ignore
@@ -26,6 +27,12 @@ from google.cloud import bigquery
 from . import discovery, gbstats_compute
 from . import metrics as metric_definitions_module
 from . import output_writing, sql_generation, sql_running
+
+logger = logging.getLogger(__name__)
+
+# The logger a run's log table collects from: this package's rather than the root logger, so the
+# table holds what this job said and not what the clients it calls said.
+PACKAGE_LOGGER = __name__.partition(".")[0]
 
 # The covariate window: days before a unit's enrollment used to predict its post-enrollment value.
 # Fixed rather than matched to each window's length, so one pre-period serves every window of a
@@ -60,86 +67,158 @@ def run_daily_job(
     query IS broken for everyone, and it is the case `systemic_failure` exists to catch. Isolation
     still holds for the per-experiment statistics below, which is where experiment-specific faults
     arise.
+
+    The whole run happens inside its log, which is written whether or not the run reaches the end of
+    this function. A run that dies partway is the one its log is worth most for, and under Airflow
+    the only other account of it is a stdout nobody queries.
     """
     outputs = outputs or output_writing.Outputs()
+    write_tables = writes_tables(validate_only, only_slugs, limit, sample_percent, outputs)
     client = bigquery.Client(project=billing_project)
     storage_client = storage.Client()
-    experiments, skipped = discovery.discover(
-        client, as_of, limit=limit, only_slugs=only_slugs
-    )
-    report_selection(experiments, skipped, as_of)
-    if not experiments:
-        return []
+    with collecting_run_log(as_of, client, outputs, write_tables):
+        experiments, skipped = discovery.discover(
+            client, as_of, limit=limit, only_slugs=only_slugs
+        )
+        report_selection(experiments, skipped, as_of)
+        if not experiments:
+            return []
 
-    metrics_by_source = metric_definitions_module.metric_definitions()
-    windows_by_slug = {
-        experiment.slug: run_windows(experiment, as_of, metrics_by_source)
-        for experiment in experiments
-    }
-    run = sql_generation.Run(
-        experiments, windows_by_slug, as_of, COVARIATE_DAYS, sample_percent
-    )
-
-    cells_by_slug, timings, failure = gather_sufficient_statistics(
-        client, run, metrics_by_source, as_of, validate_only
-    )
-    write_blobs = writes_blobs(validate_only, sample_percent, outputs)
-
-    # No lock: `as_completed` yields in this thread, so the accumulation below is single-threaded.
-    summaries, results_by_slug, done = [], {}, 0
-    with ThreadPoolExecutor(max_workers=workers) as pool:
-        futures = [
-            pool.submit(
-                analyze_experiment,
-                storage_client,
-                experiment,
-                as_of,
-                windows_by_slug[experiment.slug],
-                metrics_by_source,
-                cells_by_slug.get(experiment.slug, {}),
-                failure,
-                outputs,
-                write_blobs,
-            )
+        metrics_by_source = metric_definitions_module.metric_definitions()
+        windows_by_slug = {
+            experiment.slug: run_windows(experiment, as_of, metrics_by_source)
             for experiment in experiments
-        ]
-        for future in as_completed(futures):
-            summary, results = future.result()
-            summaries.append(summary)
-            results_by_slug[summary["slug"]] = results
-            done += 1
-            report_progress(summary, done, len(experiments))
+        }
+        run = sql_generation.Run(
+            experiments, windows_by_slug, as_of, COVARIATE_DAYS, sample_percent
+        )
 
-    if is_partial_run(only_slugs, limit, sample_percent):
-        # A partial run is not the day's complete output, and the write replaces the whole
-        # partition, so letting it through would overwrite the full run's rows. A filter drops
-        # experiments the partition should still hold; a sample keeps every experiment but computes
-        # each from a fraction of its cohort, which is the more dangerous of the two because the
-        # rows it writes look complete.
-        blobs = "blobs written" if write_blobs else "blobs skipped"
-        print(
-            f"\npartial run ({len(experiments)} experiments): {blobs}, tables skipped "
-            f"so the {as_of} partition keeps the full run's rows"
+        cells_by_slug, timings, failure = gather_sufficient_statistics(
+            client, run, metrics_by_source, as_of, validate_only
         )
-    elif outputs.local_blob_dir:
-        # Blobs went to a directory, so there is nowhere for the tables to be part of the same
-        # output. Writing them would put a local run's numbers in the production partition.
-        print(f"\nlocal run: blobs written to {outputs.local_blob_dir}, tables skipped")
-    elif not validate_only:
-        # After the loop, not inside it. Every experiment's rows share one daily partition, so a
-        # per-experiment write could only append, and appending makes a retried run double its own
-        # output. Writing the run together lets the load replace the partition instead.
-        written = output_writing.write_tables(
-            client, as_of, results_by_slug, cells_by_slug, outputs
-        )
-        print(
-            f"\nwrote {written[0]:,} statistics rows and {written[1]:,} "
-            f"sufficient-statistics rows for {as_of}"
-        )
-    report_run(summaries, timings)
-    if not validate_only:
-        report_anomalies(summaries)
-    return summaries
+        write_blobs = writes_blobs(validate_only, sample_percent, outputs)
+
+        # No lock: `as_completed` yields in this thread, so the accumulation below is
+        # single-threaded.
+        summaries, results_by_slug, done = [], {}, 0
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = [
+                pool.submit(
+                    analyze_experiment,
+                    storage_client,
+                    experiment,
+                    as_of,
+                    windows_by_slug[experiment.slug],
+                    metrics_by_source,
+                    cells_by_slug.get(experiment.slug, {}),
+                    failure,
+                    outputs,
+                    write_blobs,
+                )
+                for experiment in experiments
+            ]
+            for future in as_completed(futures):
+                summary, results = future.result()
+                summaries.append(summary)
+                results_by_slug[summary["slug"]] = results
+                done += 1
+                report_progress(summary, done, len(experiments))
+
+        if is_partial_run(only_slugs, limit, sample_percent):
+            # A partial run is not the day's complete output, and the write replaces the whole
+            # partition, so letting it through would overwrite the full run's rows. A filter drops
+            # experiments the partition should still hold; a sample keeps every experiment but
+            # computes each from a fraction of its cohort, which is the more dangerous of the two
+            # because the rows it writes look complete.
+            blobs = "blobs written" if write_blobs else "blobs skipped"
+            logger.info(
+                f"partial run ({len(experiments)} experiments): {blobs}, tables skipped "
+                f"so the {as_of} partition keeps the full run's rows"
+            )
+        elif outputs.local_blob_dir:
+            # Blobs went to a directory, so there is nowhere for the tables to be part of the same
+            # output. Writing them would put a local run's numbers in the production partition.
+            logger.info(
+                f"local run: blobs written to {outputs.local_blob_dir}, tables skipped"
+            )
+        elif write_tables:
+            # After the loop, not inside it. Every experiment's rows share one daily partition, so a
+            # per-experiment write could only append, and appending makes a retried run double its
+            # own output. Writing the run together lets the load replace the partition instead.
+            written = output_writing.write_tables(
+                client, as_of, results_by_slug, cells_by_slug, outputs
+            )
+            logger.info(
+                f"wrote {written[0]:,} statistics rows and {written[1]:,} "
+                f"sufficient-statistics rows for {as_of}"
+            )
+        report_run(summaries, timings)
+        if not validate_only:
+            report_anomalies(summaries)
+        # Logged as well as returned, because the exit code it produces is not a thing anyone can
+        # query afterwards for the reason the run ended.
+        if systemic_failure(summaries):
+            logger.error("no experiment produced a result: the run failed as a whole")
+        return summaries
+
+
+@contextlib.contextmanager
+def collecting_run_log(as_of, client, outputs, write_tables):
+    """Collect everything the block logs, and write it whether or not the block finishes.
+
+    A context manager rather than a `try` in the caller, so that the behaviour this table exists
+    for, a run that died recording why, is a property of something exercisable without a run.
+    """
+    run_log = start_run_log(as_of)
+    try:
+        yield run_log
+    finally:
+        finish_run_log(run_log, client, as_of, outputs, write_tables)
+
+
+def start_run_log(as_of):
+    """Attach a handler collecting this run's log records, and return it.
+
+    The level is set here rather than inherited from whatever configured stdout, because what the
+    log table holds should not depend on how loud the terminal was asked to be.
+    """
+    package_logger = logging.getLogger(PACKAGE_LOGGER)
+    package_logger.setLevel(logging.INFO)
+    run_log = output_writing.RunLog(as_of)
+    package_logger.addHandler(run_log)
+    return run_log
+
+
+def finish_run_log(run_log, client, as_of, outputs, write_tables):
+    """Write the run's log, and detach it whether or not that write happens.
+
+    Detached before the write rather than after it, so that a write which fails and says so does
+    not append its own complaint to the records it is failing to write.
+    """
+    logging.getLogger(PACKAGE_LOGGER).removeHandler(run_log)
+    if not write_tables:
+        return 0
+    try:
+        return output_writing.write_log_table(client, as_of, run_log.rows, outputs)
+    # Raising would replace whatever ended the run with a failure to record it, which is the one
+    # error worth less than the error it would hide.
+    except Exception:
+        logger.exception(f"could not write the run log to {outputs.log_table}")
+        return 0
+
+
+def writes_tables(validate_only, only_slugs, limit, sample_percent, outputs):
+    """Whether this run may write the tables, its log among them.
+
+    One rule for all three, rather than a rule of the log's own. A partial run's rows do not belong
+    in a partition the full run's rows belong in, a local run has nowhere for the tables to be part
+    of the same output, and a validation run executes nothing to have results of; in each case a log
+    describing that run does not belong in the day's partition either, since it would replace the
+    log of the run whose rows are there.
+    """
+    if validate_only or outputs.local_blob_dir:
+        return False
+    return not is_partial_run(only_slugs, limit, sample_percent)
 
 
 def is_partial_run(only_slugs, limit, sample_percent):
@@ -189,7 +268,9 @@ def gather_sufficient_statistics(client, run, metrics_by_source, as_of, validate
     # Recorded against every experiment rather than raised, so a source failure becomes an error
     # grid instead of an exception that ends the run having written nothing.
     except Exception as error:
-        traceback.print_exc()
+        # Logged once here rather than once per experiment: every experiment's grid records it, and
+        # the reason it happened is a property of the run.
+        logger.exception("the shared scan failed, so every experiment records an error grid")
         return {}, [], error
 
 
@@ -202,9 +283,13 @@ def report_progress(summary, done, total):
     """
     flag = "ERROR" if (summary["states"].get("error") or summary["error"]) else "ok   "
     reason = f"  {summary['error']}" if summary["error"] else ""
-    print(
+    # Progress rather than a failure, at whatever the outcome, so that a query for this run's
+    # failures returns them and not a line per experiment analysed. The failures themselves are
+    # logged where they are caught, with the traceback this line has no room for.
+    logger.info(
         f"[{done:3d}/{total}] {flag} {summary['slug'][:52]:52s} "
-        f"{summary['cells']:5d} cells{reason}"
+        f"{summary['cells']:5d} cells{reason}",
+        extra={"experiment_slug": summary["slug"]},
     )
 
 
@@ -251,6 +336,11 @@ def analyze_experiment(
         return experiment_summary(experiment, results), results
     # The whole point is to record it, not to raise.
     except Exception as error:
+        # An experiment that failed here may produce no row at all, and a row is the only thing the
+        # results table can carry an error on, so this is the one place the failure is recorded.
+        logger.exception(
+            f"{experiment.slug} failed", extra={"experiment_slug": experiment.slug}
+        )
         try:
             return failed_summary(
                 storage_client,
@@ -266,7 +356,10 @@ def analyze_experiment(
             # A failure while recording a failure must not propagate: it would come back out of
             # future.result() and cost every other experiment its results, which is exactly the
             # isolation this design claims to have.
-            traceback.print_exc()
+            logger.exception(
+                f"{experiment.slug} failed while recording a failure",
+                extra={"experiment_slug": experiment.slug},
+            )
             return (
                 experiment_summary(
                     experiment,
@@ -305,7 +398,10 @@ def failed_summary(
             # Recording the error grid must not depend on the thing that just failed. The grid is
             # returned either way, so the failure stays visible in this run's accounting and in the
             # table written at the end, even when the blob could not be written.
-            traceback.print_exc()
+            logger.exception(
+                f"could not write {experiment.slug}'s blob",
+                extra={"experiment_slug": experiment.slug},
+            )
     return experiment_summary(experiment, results, error=error), results
 
 
@@ -344,16 +440,20 @@ def experiment_summary(experiment, results, error=None):
 
 
 def report_selection(experiments, skipped, as_of):
-    """Print which experiments the run will analyse, and why the others were skipped."""
-    print(
+    """Report which experiments the run will analyse, and why the others were skipped.
+
+    A skip is a warning rather than progress: it is the run declining to analyse a recipe that is
+    live, which someone reading the corpus later has to be able to find the reason for.
+    """
+    logger.info(
         f"as_of {as_of}: {len(experiments)} experiments to analyse, {len(skipped)} skipped"
     )
     for slug, why in skipped:
-        print(f"   skipped {slug}: {why}")
+        logger.warning(f"skipped {slug}: {why}", extra={"experiment_slug": slug})
 
 
 def report_run(summaries, timings):
-    """Print the per-run operational summary: what it consumed and how many cells failed.
+    """Report the per-run operational summary: what it consumed and how many cells failed.
 
     Bytes scanned and slot-hours are consumption rather than a price, since the slots are a shared
     reservation. Both are properties of the run and not of an experiment: one pass over each source
@@ -362,20 +462,20 @@ def report_run(summaries, timings):
     cells = sum(summary["cells"] for summary in summaries)
     errors = sum(summary["states"].get("error", 0) for summary in summaries)
     failed = sum(1 for summary in summaries if summary["error"])
-    print(
-        f"\n{len(summaries)} experiments ({failed} failed outright), {cells:,} cells, "
+    logger.info(
+        f"{len(summaries)} experiments ({failed} failed outright), {cells:,} cells, "
         f"{sum(timing['gigabytes_scanned'] for timing in timings) / 1000:.2f} TB scanned, "
         f"{sum(timing['slot_hours'] or 0 for timing in timings):.1f} slot-hours "
         f"over {len(timings)} queries"
     )
     for timing in timings:
-        print(
-            f"   {timing['source']:30s} {timing['wall_seconds']:8.1f}s "
+        logger.info(
+            f"{timing['source']:30s} {timing['wall_seconds']:8.1f}s "
             f"{timing['gigabytes_scanned'] / 1000:7.2f} TB "
             f"{timing['slot_hours'] if timing['slot_hours'] is not None else '-'} slot-h "
             f"{timing['rows']:,} rows"
         )
-    print(
+    logger.info(
         f"error rate {errors / cells:.2%} ({errors:,} of {cells:,} cells)"
         if cells
         else "no cells produced"
@@ -432,6 +532,6 @@ def report_anomalies(summaries):
         if summary["cells"] == 0:
             suspicious.append((summary["slug"], "no cells: no window has matured yet"))
     if suspicious:
-        print(f"\n{len(suspicious)} experiments to look at:")
+        logger.info(f"{len(suspicious)} experiments to look at:")
         for slug, why in suspicious:
-            print(f"   {slug[:56]:56s} {why}")
+            logger.warning(f"{slug}: {why}", extra={"experiment_slug": slug})

--- a/jobs/highwind/highwind/analysis.py
+++ b/jobs/highwind/highwind/analysis.py
@@ -173,7 +173,7 @@ def collecting_run_log(as_of, client, outputs, write_tables):
     try:
         yield run_log
     finally:
-        finish_run_log(run_log, client, as_of, outputs, write_tables)
+        finish_run_log(run_log, client, outputs, write_tables)
 
 
 def start_run_log(as_of):
@@ -189,7 +189,7 @@ def start_run_log(as_of):
     return run_log
 
 
-def finish_run_log(run_log, client, as_of, outputs, write_tables):
+def finish_run_log(run_log, client, outputs, write_tables):
     """Write the run's log, and detach it whether or not that write happens.
 
     Detached before the write rather than after it, so that a write which fails and says so does
@@ -199,7 +199,7 @@ def finish_run_log(run_log, client, as_of, outputs, write_tables):
     if not write_tables:
         return 0
     try:
-        return output_writing.write_log_table(client, as_of, run_log.rows, outputs)
+        return output_writing.write_log_table(client, run_log.rows, outputs)
     # Raising would replace whatever ended the run with a failure to record it, which is the one
     # error worth less than the error it would hide.
     except Exception:

--- a/jobs/highwind/highwind/main.py
+++ b/jobs/highwind/highwind/main.py
@@ -3,16 +3,18 @@
 A thin entry point. Everything it calls lives in the `highwind` package, because the analysis is
 several modules rather than one script. See `analysis.py` for the flow.
 
-One run writes three things:
+One run writes four things:
 
     highwind_statistics_v1        one row per (slug, metric, window, comparison), the results
     highwind_sufficient_stats_v1  one row per (slug, metric, window, branch), what they came from
+    highwind_logs_v1              one row per log record, why a run or an experiment went wrong
     gs://mozanalysis/highwind/<slug>.json   per-experiment results, the seam Experimenter reads,
                                             named with the slug's hyphens as underscores
 
-All three come from one computation, which is why they are one job rather than three.
+All four come from one computation, which is why they are one job rather than four.
 """
 
+import logging
 import sys
 
 import click
@@ -26,6 +28,11 @@ from highwind.output_writing import Outputs
 
 DEFAULT_WORKERS = 8
 DEFAULT_LOCAL_OUTPUT = "test_output"
+
+# Level and message only. The run then reads as the progress report it was before any of it went
+# through a logger, and the timestamp a reader wants against a line is on that line's row in the log
+# table rather than in front of it here.
+LOG_FORMAT = "%(levelname)-7s %(message)s"
 
 
 @click.command()
@@ -116,6 +123,7 @@ def main(
     billing_project,
 ):
     """Analyse every live Firefox Desktop experiment for the run date."""
+    configure_logging()
     summaries = run_daily_job(
         as_of=run_date.date(),
         only_slugs=list(slugs) or None,
@@ -130,6 +138,15 @@ def main(
     # nothing, which is the failure mode hardest to notice and slowest to diagnose.
     if systemic_failure(summaries):
         raise SystemExit("Highwind produced no results for any experiment")
+
+
+def configure_logging():
+    """Send the run's log to stdout, which is what a container's logs are.
+
+    Configured once, here, rather than in the analysis: the analysis decides what to say and at what
+    level, and where that goes is a property of how the job was started.
+    """
+    logging.basicConfig(level=logging.INFO, format=LOG_FORMAT, stream=sys.stdout)
 
 
 if __name__ == "__main__":

--- a/jobs/highwind/highwind/output_writing.py
+++ b/jobs/highwind/highwind/output_writing.py
@@ -4,11 +4,18 @@ Two destinations, for two different readers. BigQuery keeps the corpus queryable
 which is what makes cross-experiment context and meta-analysis possible and lets a result be
 inspected without opening a blob. GCS is the seam Experimenter reads, matching where the enrollment
 funnel already writes from this same Airflow.
+
+A third table holds what the run logged. A cell that failed is already queryable, because the
+results grid is written whole and carries a state and an error, but an experiment that failed before
+producing any cell has no row to carry one, and neither has a refused recipe or a run-level event.
+Those reach stdout, which under Airflow is the account nobody reads.
 """
 
 import datetime
 import json
+import logging
 import pathlib
+import traceback
 from dataclasses import dataclass
 
 from google.cloud import bigquery
@@ -19,13 +26,19 @@ RESULTS_TABLE = "moz-fx-data-experiments.highwind_poc.highwind_statistics_v1"
 SUFFICIENT_STATS_TABLE = (
     "moz-fx-data-experiments.highwind_poc.highwind_sufficient_stats_v1"
 )
+LOG_TABLE = "moz-fx-data-experiments.highwind_poc.highwind_logs_v1"
 BLOB_PREFIX = "gs://mozanalysis/highwind"
 PIPELINE_VERSION = "poc-1"
 
-# The column both tables are partitioned on, and the run date every row carries.
+# What every log row is attributed to. Jetstream's log handler carries the same column so one table
+# can hold several producers' logs, and it is kept here for the same reason the column names below
+# are: adopting that handler in place of this one should be a swap rather than a migration.
+LOG_SOURCE = "highwind"
+
+# The column every table is partitioned on, and the run date every row carries.
 PARTITION_FIELD = "as_of_date"
 
-# The column both tables are clustered on. Reading one experiment's results is the common query, so
+# The column every table is clustered on. Reading one experiment's results is the common query, so
 # clustering on the slug lets it prune blocks rather than scan the whole partition. It matters more
 # as the corpus grows, since a partition holds every experiment analysed that day.
 CLUSTERING_FIELDS = ["experiment_slug"]
@@ -233,10 +246,105 @@ SUFFICIENT_STATS_SCHEMA = [
     ),
 ]
 
+# One row per log record the run emitted. The columns after the first two are the ones Jetstream's
+# own BigQuery log handler writes, names included, so that adopting that handler here later is a
+# swap rather than a rewrite of everything reading this table.
+LOG_SCHEMA = [
+    bigquery.SchemaField(
+        "as_of_date",
+        "DATE",
+        description="Run date the record was logged for. Partition column.",
+    ),
+    bigquery.SchemaField(
+        "experiment_slug",
+        "STRING",
+        description=(
+            "Experiment the record is about, NULL for a record about the run as a whole. "
+            "Jetstream's column of this concept is named experiment; it is named for the slug "
+            "here to match the two tables beside it, which is also what lets it be the clustering "
+            "column they cluster on."
+        ),
+    ),
+    bigquery.SchemaField(
+        "timestamp", "TIMESTAMP", description="When the record was logged, in UTC."
+    ),
+    bigquery.SchemaField(
+        "log_level",
+        "STRING",
+        description=(
+            "INFO for progress and for what the run consumed, WARNING for a recipe the run "
+            "refused to analyse and for a result that ran but does not look like an analysis, "
+            "ERROR for a failure."
+        ),
+    ),
+    bigquery.SchemaField("message", "STRING", description="The record's message."),
+    bigquery.SchemaField(
+        "exception",
+        "STRING",
+        description=(
+            "Formatted traceback of the exception the record carries, NULL when it carries none. "
+            "The traceback rather than the exception's text, because the line that raised is the "
+            "diagnosis and the message does not carry it."
+        ),
+    ),
+    bigquery.SchemaField(
+        "exception_type",
+        "STRING",
+        description="Class name of that exception, which is what an error rate groups by.",
+    ),
+    bigquery.SchemaField(
+        "filename", "STRING", description="File the record was logged from."
+    ),
+    bigquery.SchemaField(
+        "func_name", "STRING", description="Function the record was logged from."
+    ),
+    bigquery.SchemaField(
+        "source",
+        "STRING",
+        description=(
+            "Which producer wrote the row, so one table can hold more than this job's logs."
+        ),
+    ),
+    bigquery.SchemaField(
+        "metric",
+        "STRING",
+        description="Metric the record is about, NULL when it is about none.",
+    ),
+    bigquery.SchemaField(
+        "statistic",
+        "STRING",
+        description="Statistic the record is about, NULL when it is about none.",
+    ),
+    bigquery.SchemaField(
+        "analysis_basis",
+        "STRING",
+        description=(
+            "Always NULL. Carried by the handler this schema follows and unimplemented here, "
+            "since this job analyses on enrollment alone; declared so that implementing it is a "
+            "value to fill rather than a column to add."
+        ),
+    ),
+    bigquery.SchemaField(
+        "segment",
+        "STRING",
+        description=(
+            "Always NULL, for the same reason as analysis_basis: this job analyses no segments."
+        ),
+    ),
+    bigquery.SchemaField(
+        "analysis_period",
+        "STRING",
+        description=(
+            "Always NULL, for the same reason again. The window is this job's equivalent, and it "
+            "is a property of a cell, which the results table already carries one of per row."
+        ),
+    ),
+]
+
 
 @dataclass(frozen=True)
 class Outputs:
-    """Where one run's three outputs go.
+    """Where one run's outputs go.
 
     An argument rather than module state, so a writer's behaviour is a function of what it was
     called with. A local run overrides the tables and sends blobs to a directory instead of GCS.
@@ -244,6 +352,7 @@ class Outputs:
 
     results_table: str = RESULTS_TABLE
     sufficient_stats_table: str = SUFFICIENT_STATS_TABLE
+    log_table: str = LOG_TABLE
     blob_prefix: str = BLOB_PREFIX
     # Set for a local run: blobs go to this directory instead of to GCS.
     local_blob_dir: str | None = None
@@ -331,6 +440,92 @@ def write_tables(client, as_of, results_by_slug, cells_by_slug, outputs):
         client, outputs.sufficient_stats_table, SUFFICIENT_STATS_SCHEMA, stats_rows, as_of
     )
     return len(results_rows), len(stats_rows)
+
+
+class RunLog(logging.Handler):
+    """Collect the records a run logs, so the run can write them as one load job at the end.
+
+    A handler rather than a collector passed down through the analysis, so that anything which logs
+    is recorded without having been handed somewhere to record it. That matters for the failures
+    this table exists for, which are caught in places that have no reason to know a table is being
+    written.
+
+    A record becomes a row on arrival rather than at the write, because it holds the live traceback
+    of whatever raised and the write can come long after that frame is gone. Nothing flushes on a
+    capacity, unlike the buffering handler this is otherwise shaped like: the write replaces the run
+    date's partition, so a second flush would leave the table holding only the records that arrived
+    after the first.
+    """
+
+    def __init__(self, as_of, source=LOG_SOURCE):
+        super().__init__(level=logging.INFO)
+        self.as_of = as_of
+        self.source = source
+        self.rows = []
+
+    def emit(self, record):
+        try:
+            self.rows.append(log_row(record, self.as_of, self.source))
+        # A handler that raises reports the fault at the site of the log rather than at the site of
+        # the fault, so a record this cannot represent would read as a bug in whatever logged it.
+        except Exception:
+            self.handleError(record)
+
+
+def log_row(record, as_of, source):
+    """One log record as a row of the log table.
+
+    What a record is about beyond its message, the experiment and the metric, arrives as logging's
+    `extra` and so lands in the record's own namespace, which is where these are read from. Most
+    records carry none of it, which is why each is optional rather than an argument.
+    """
+    fields = vars(record)
+    exception_type, formatted = exception_columns(record.exc_info)
+    return dict(
+        as_of_date=as_of.isoformat(),
+        experiment_slug=fields.get("experiment_slug"),
+        timestamp=datetime.datetime.fromtimestamp(
+            record.created, datetime.timezone.utc
+        ).isoformat(),
+        log_level=record.levelname,
+        message=record.getMessage(),
+        exception=formatted,
+        exception_type=exception_type,
+        filename=record.filename,
+        func_name=record.funcName,
+        source=source,
+        metric=fields.get("metric"),
+        statistic=fields.get("statistic"),
+        # Declared and unfilled, so that implementing either is a value to write rather than a
+        # column to add and a reader to change. See their descriptions in LOG_SCHEMA.
+        analysis_basis=None,
+        segment=None,
+        analysis_period=None,
+    )
+
+
+def exception_columns(exc_info):
+    """The exception a record carries, as its class name and its formatted traceback.
+
+    The absent case is tested on the exception rather than on the tuple, because logging leaves a
+    record's `exc_info` a tuple of Nones when it is asked to log an exception with nothing in
+    flight, and that tuple is as truthy as a real one.
+    """
+    if not exc_info or exc_info[0] is None:
+        return None, None
+    return exc_info[0].__name__, "".join(traceback.format_exception(*exc_info))
+
+
+def write_log_table(client, as_of, rows, outputs):
+    """Write what the run logged as the whole contents of its date's partition.
+
+    Replaced rather than appended for the reason the tables above are, and with the same
+    consequence: a retry's log replaces the log of the attempt it retried, so the partition
+    describes the run that produced the day's results rather than every attempt at them.
+    """
+    ensure_table(client, outputs.log_table, LOG_SCHEMA)
+    replace_partition(client, outputs.log_table, LOG_SCHEMA, rows, as_of)
+    return len(rows)
 
 
 def ensure_table(client, table, schema):

--- a/jobs/highwind/highwind/output_writing.py
+++ b/jobs/highwind/highwind/output_writing.py
@@ -246,14 +246,24 @@ SUFFICIENT_STATS_SCHEMA = [
     ),
 ]
 
-# One row per log record the run emitted. The columns after the first two are the ones Jetstream's
-# own BigQuery log handler writes, names included, so that adopting that handler here later is a
-# swap rather than a rewrite of everything reading this table.
+# One row per log record the run emitted. The columns after the first three are the ones
+# Jetstream's own BigQuery log handler writes, names included, so that adopting that handler here
+# later is a swap rather than a rewrite of everything reading this table.
 LOG_SCHEMA = [
     bigquery.SchemaField(
         "as_of_date",
         "DATE",
         description="Run date the record was logged for. Partition column.",
+    ),
+    bigquery.SchemaField(
+        "run_started_at",
+        "TIMESTAMP",
+        description=(
+            "When the run that logged this record began, in UTC. Constant across every row one "
+            "run writes, and the only thing separating one attempt at a date from another, since "
+            "this table is appended to rather than replaced. Group by it to read a single "
+            "attempt, and take the greatest value in a date to read the most recent one."
+        ),
     ),
     bigquery.SchemaField(
         "experiment_slug",
@@ -452,27 +462,33 @@ class RunLog(logging.Handler):
 
     A record becomes a row on arrival rather than at the write, because it holds the live traceback
     of whatever raised and the write can come long after that frame is gone. Nothing flushes on a
-    capacity, unlike the buffering handler this is otherwise shaped like: the write replaces the run
-    date's partition, so a second flush would leave the table holding only the records that arrived
-    after the first.
+    capacity, unlike the buffering handler this is otherwise shaped like: one run's records are one
+    attempt, and a flush part way through would split that attempt across two loads with no way to
+    tell it was ever one.
+
+    The start time is taken here, once, rather than per record, because it identifies the attempt
+    rather than the record. Every row this handler makes carries the same value.
     """
 
     def __init__(self, as_of, source=LOG_SOURCE):
         super().__init__(level=logging.INFO)
         self.as_of = as_of
         self.source = source
+        self.run_started_at = datetime.datetime.now(datetime.timezone.utc)
         self.rows = []
 
     def emit(self, record):
         try:
-            self.rows.append(log_row(record, self.as_of, self.source))
+            self.rows.append(
+                log_row(record, self.as_of, self.run_started_at, self.source)
+            )
         # A handler that raises reports the fault at the site of the log rather than at the site of
         # the fault, so a record this cannot represent would read as a bug in whatever logged it.
         except Exception:
             self.handleError(record)
 
 
-def log_row(record, as_of, source):
+def log_row(record, as_of, run_started_at, source):
     """One log record as a row of the log table.
 
     What a record is about beyond its message, the experiment and the metric, arrives as logging's
@@ -483,6 +499,7 @@ def log_row(record, as_of, source):
     exception_type, formatted = exception_columns(record.exc_info)
     return dict(
         as_of_date=as_of.isoformat(),
+        run_started_at=run_started_at.isoformat(),
         experiment_slug=fields.get("experiment_slug"),
         timestamp=datetime.datetime.fromtimestamp(
             record.created, datetime.timezone.utc
@@ -516,15 +533,21 @@ def exception_columns(exc_info):
     return exc_info[0].__name__, "".join(traceback.format_exception(*exc_info))
 
 
-def write_log_table(client, as_of, rows, outputs):
-    """Write what the run logged as the whole contents of its date's partition.
+def write_log_table(client, rows, outputs):
+    """Append what the run logged to the log table.
 
-    Replaced rather than appended for the reason the tables above are, and with the same
-    consequence: a retry's log replaces the log of the attempt it retried, so the partition
-    describes the run that produced the day's results rather than every attempt at them.
+    Appended rather than replacing the date's partition, which is the one place this job differs
+    from the tables above. Those hold results, so a rerun's output supersedes the attempt it
+    retried and replacing is what makes the rerun idempotent. This holds the account of what
+    happened, and the attempt that failed is usually the reason a rerun exists at all, so replacing
+    would delete the explanation on the way to producing the fix. Every attempt at a date is kept
+    and `run_started_at` is what separates them.
+
+    The cost of keeping them is that a date accumulates rows across attempts, so anything reading
+    this table for the state of a date has to pick an attempt rather than assume there is one.
     """
     ensure_table(client, outputs.log_table, LOG_SCHEMA)
-    replace_partition(client, outputs.log_table, LOG_SCHEMA, rows, as_of)
+    append_rows(client, outputs.log_table, LOG_SCHEMA, rows)
     return len(rows)
 
 
@@ -540,6 +563,28 @@ def ensure_table(client, table, schema):
     definition.time_partitioning = bigquery.TimePartitioning(field=PARTITION_FIELD)
     definition.clustering_fields = CLUSTERING_FIELDS
     client.create_table(definition, exists_ok=True)
+
+
+def append_rows(client, table, schema, rows):
+    """Add `rows` to `table`, leaving what is already there alone.
+
+    No partition decorator on the target: the rows carry their own `as_of_date` and BigQuery files
+    each one into the partition that column names, where a decorator would instead assert that
+    every row belongs to one date.
+
+    The schema is passed explicitly and inference switched off for the same reason as below, and
+    with an added one: an appending load that inferred its schema would reconcile it against the
+    live table on every run, so a column absent from one attempt's records is a schema change
+    rather than an empty column.
+    """
+    if not rows:
+        return
+    config = bigquery.LoadJobConfig(
+        write_disposition=bigquery.WriteDisposition.WRITE_APPEND,
+        autodetect=False,
+        schema=schema,
+    )
+    client.load_table_from_json(rows, table, job_config=config).result()
 
 
 def replace_partition(client, table, schema, rows, as_of):

--- a/jobs/highwind/tests/test_analysis.py
+++ b/jobs/highwind/tests/test_analysis.py
@@ -1,6 +1,9 @@
-"""Whether a run failed as a whole, which is what the process exit code turns on."""
+"""Whether a run failed as a whole, and what it records about the ways it can fail."""
 
 import datetime
+import logging
+
+import pytest
 
 from highwind import analysis, output_writing, units
 from highwind.discovery import Experiment
@@ -23,6 +26,31 @@ EXPERIMENT = Experiment(
     treatment_branches=("treatment-a",),
     unit=units.resolve("firefox_desktop", "normandy_id"),
 )
+
+
+class FakeLoadJob:
+    def result(self):
+        return None
+
+
+class RecordingClient:
+    """Stands in for a BigQuery client, recording what a run loaded."""
+
+    def __init__(self):
+        self.created = []
+        self.loads = []
+
+    def create_table(self, table, exists_ok=False):
+        self.created.append(table)
+        return table
+
+    def load_table_from_json(self, rows, target, job_config=None):
+        self.loads.append((target, rows))
+        return FakeLoadJob()
+
+    @property
+    def log_rows(self):
+        return [row for _, rows in self.loads for row in rows]
 
 
 class RecordingBlob:
@@ -128,7 +156,9 @@ def test_a_failure_while_recording_a_failure_is_still_returned_not_raised():
     assert "recording it also failed" in recorded["error"]
 
 
-def test_the_run_report_counts_cells_and_errors_across_experiments(capsys):
+def test_the_run_report_counts_cells_and_errors_across_experiments(caplog):
+    caplog.set_level(logging.INFO)
+
     analysis.report_run(
         [summary("a", {CONFIDENT: 1, ERROR: 1}), summary("b", {FORMING: 2})],
         [
@@ -141,20 +171,22 @@ def test_the_run_report_counts_cells_and_errors_across_experiments(capsys):
             )
         ],
     )
-    printed = capsys.readouterr().out
 
-    assert "2 experiments (0 failed outright)" in printed
-    assert "error rate 25.00%" in printed
+    assert "2 experiments (0 failed outright)" in caplog.text
+    assert "error rate 25.00%" in caplog.text
 
 
-def test_the_run_report_says_so_rather_than_dividing_by_zero_cells(capsys):
+def test_the_run_report_says_so_rather_than_dividing_by_zero_cells(caplog):
+    caplog.set_level(logging.INFO)
+
     analysis.report_run([summary("a", {})], [])
-    printed = capsys.readouterr().out
 
-    assert "no cells produced" in printed
+    assert "no cells produced" in caplog.text
 
 
-def test_an_experiment_whose_cells_are_all_immature_is_reported_as_worth_a_look(capsys):
+def test_an_experiment_whose_cells_are_all_immature_is_reported_as_worth_a_look(caplog):
+    caplog.set_level(logging.INFO)
+
     analysis.report_anomalies(
         [
             summary("a", {NOT_STARTED: 12}),
@@ -162,11 +194,110 @@ def test_an_experiment_whose_cells_are_all_immature_is_reported_as_worth_a_look(
             summary("c", {}),
         ]
     )
-    printed = capsys.readouterr().out
 
-    assert "cohort or join empty" in printed
-    assert "no cells: no window has matured yet" in printed
-    assert "\n   b " not in printed
+    assert "cohort or join empty" in caplog.text
+    assert "no cells: no window has matured yet" in caplog.text
+    # Each is attributed to the experiment it is about, so a reader looking one up finds the reason
+    # against its slug rather than in a line they have to parse. The healthy one is not flagged.
+    flagged = [
+        record.experiment_slug
+        for record in caplog.records
+        if record.levelno == logging.WARNING
+    ]
+    assert flagged == ["a", "c"]
+
+
+def test_a_refused_recipe_is_recorded_against_its_slug_with_the_reason(caplog):
+    client = RecordingClient()
+
+    with analysis.collecting_run_log(AS_OF, client, output_writing.Outputs(), True):
+        analysis.report_selection(
+            [EXPERIMENT], [("a-refused-slug", "reference=None others=()")], AS_OF
+        )
+
+    refusals = [row for row in client.log_rows if row["log_level"] == "WARNING"]
+    assert len(refusals) == 1
+    assert refusals[0]["experiment_slug"] == "a-refused-slug"
+    assert "reference=None" in refusals[0]["message"]
+
+
+def test_an_experiment_that_fails_outright_is_recorded_against_its_slug():
+    # It produces no results row of its own to carry an error on, unlike a cell that failed, so the
+    # log is the only place its failure can be found.
+    client = RecordingClient()
+
+    with analysis.collecting_run_log(AS_OF, client, output_writing.Outputs(), True):
+        analysis.analyze_experiment(
+            None,
+            EXPERIMENT,
+            AS_OF,
+            [],
+            {"clients_daily": None},
+            {},
+            "the shared scan failed",
+            None,
+            write_blobs=False,
+        )
+
+    failures = [row for row in client.log_rows if row["log_level"] == "ERROR"]
+    assert failures
+    assert all(row["experiment_slug"] == "a-slug" for row in failures)
+    assert all(row["exception_type"] for row in failures)
+    assert all(row["exception"] for row in failures)
+
+
+def test_the_log_is_written_even_when_the_run_it_covers_raises():
+    # The run this table is worth most for is the one that died, so the write cannot be a step the
+    # run reaches only by finishing.
+    client = RecordingClient()
+
+    with pytest.raises(RuntimeError):
+        with analysis.collecting_run_log(AS_OF, client, output_writing.Outputs(), True):
+            analysis.report_selection([], [("a-slug", "a reason")], AS_OF)
+            raise RuntimeError("whatever ended the run")
+
+    assert [row["experiment_slug"] for row in client.log_rows] == [None, "a-slug"]
+
+
+def test_a_partial_run_writes_no_log_rows_any_more_than_it_writes_results():
+    client = RecordingClient()
+    write_tables = analysis.writes_tables(
+        False, ["a-slug"], None, None, output_writing.Outputs()
+    )
+
+    with analysis.collecting_run_log(
+        AS_OF, client, output_writing.Outputs(), write_tables
+    ):
+        analysis.report_selection([EXPERIMENT], [("a-slug", "a reason")], AS_OF)
+
+    assert write_tables is False
+    assert client.loads == []
+
+
+def test_the_log_table_is_written_by_exactly_the_runs_that_write_the_result_tables():
+    # One rule for all three tables: a log describing a run whose rows were withheld would replace
+    # the log of the run whose rows are in the partition.
+    published = output_writing.Outputs()
+    local = output_writing.Outputs(local_blob_dir="test_output")
+
+    assert analysis.writes_tables(False, None, None, None, published) is True
+    assert analysis.writes_tables(True, None, None, None, published) is False
+    assert analysis.writes_tables(False, ["a"], None, None, published) is False
+    assert analysis.writes_tables(False, None, 5, None, published) is False
+    assert analysis.writes_tables(False, None, None, 1, published) is False
+    assert analysis.writes_tables(False, None, None, None, local) is False
+
+
+def test_a_log_that_cannot_be_written_does_not_replace_whatever_ended_the_run():
+    class FailingClient:
+        def create_table(self, table, exists_ok=False):
+            raise RuntimeError("the log table could not be created")
+
+    with pytest.raises(RuntimeError, match="whatever ended the run"):
+        with analysis.collecting_run_log(
+            AS_OF, FailingClient(), output_writing.Outputs(), True
+        ):
+            raise RuntimeError("whatever ended the run")
 
 
 def test_a_sampled_run_is_treated_as_partial_so_it_cannot_overwrite_the_partition():

--- a/jobs/highwind/tests/test_output_writing.py
+++ b/jobs/highwind/tests/test_output_writing.py
@@ -2,6 +2,7 @@
 
 import datetime
 import json
+import logging
 import pathlib
 
 from highwind import output_writing, units
@@ -96,6 +97,19 @@ class FakeBucket:
 class FakeStorage:
     def bucket(self, name):
         return FakeBucket(name)
+
+
+def log_rows_of(emit, as_of=AS_OF):
+    """The rows a run log makes of whatever `emit` logs through a logger of its own."""
+    run_log = output_writing.RunLog(as_of)
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.INFO)
+    logger.addHandler(run_log)
+    try:
+        emit(logger)
+    finally:
+        logger.removeHandler(run_log)
+    return run_log.rows
 
 
 def write_one_run(client, outputs=None):
@@ -243,6 +257,99 @@ def test_a_run_with_no_rows_leaves_the_partition_alone():
 
     assert written == (0, 0)
     assert client.loads == []
+
+
+def test_a_logged_record_becomes_a_row_of_exactly_the_columns_declared():
+    rows = log_rows_of(lambda logger: logger.info("the run started"))
+
+    assert len(rows) == 1
+    assert set(rows[0]) == {field.name for field in output_writing.LOG_SCHEMA}
+    assert rows[0]["as_of_date"] == "2026-08-01"
+    assert rows[0]["log_level"] == "INFO"
+    assert rows[0]["message"] == "the run started"
+    assert rows[0]["source"] == output_writing.LOG_SOURCE
+    assert rows[0]["exception"] is None
+    assert rows[0]["exception_type"] is None
+
+
+def test_a_failure_is_recorded_with_its_type_and_the_traceback_of_the_line_that_raised():
+    def emit(logger):
+        try:
+            raise RuntimeError("the query failed")
+        except RuntimeError:
+            logger.exception("an experiment failed")
+
+    rows = log_rows_of(emit)
+
+    assert rows[0]["log_level"] == "ERROR"
+    assert rows[0]["exception_type"] == "RuntimeError"
+    assert "the query failed" in rows[0]["exception"]
+    assert 'raise RuntimeError("the query failed")' in rows[0]["exception"]
+
+
+def test_a_record_asked_for_an_exception_with_none_in_flight_carries_none():
+    rows = log_rows_of(lambda logger: logger.error("nothing raised", exc_info=True))
+
+    assert rows[0]["exception"] is None
+    assert rows[0]["exception_type"] is None
+
+
+def test_what_a_record_is_about_becomes_the_columns_it_can_be_looked_up_by():
+    rows = log_rows_of(
+        lambda logger: logger.warning(
+            "worth a look",
+            extra={"experiment_slug": "an-experiment", "metric": "active_hours"},
+        )
+    )
+
+    assert rows[0]["experiment_slug"] == "an-experiment"
+    assert rows[0]["metric"] == "active_hours"
+    assert rows[0]["log_level"] == "WARNING"
+
+
+def test_the_columns_this_job_does_not_fill_yet_are_declared_and_left_empty():
+    # Declared so that analysing on another basis, or in segments, is a value to write rather than
+    # a column to add and every reader of the table to change.
+    rows = log_rows_of(lambda logger: logger.info("the run started"))
+
+    assert rows[0]["analysis_basis"] is None
+    assert rows[0]["segment"] is None
+    assert rows[0]["analysis_period"] is None
+
+
+def test_a_runs_whole_log_is_one_load_into_its_own_dates_partition():
+    def emit(logger):
+        logger.info("the run started")
+        logger.warning("a recipe was skipped")
+        logger.error("an experiment failed")
+
+    client = RecordingClient()
+    rows = log_rows_of(emit)
+
+    written = output_writing.write_log_table(
+        client, AS_OF, rows, output_writing.Outputs()
+    )
+
+    assert written == 3
+    assert [target for target, _, _ in client.loads] == [
+        f"{output_writing.LOG_TABLE}$20260801"
+    ]
+    _, loaded, config = client.loads[0]
+    assert len(loaded) == 3
+    assert config.write_disposition == "WRITE_TRUNCATE"
+    assert config.autodetect is False
+
+
+def test_the_log_table_is_partitioned_and_clustered_like_the_tables_it_sits_beside():
+    client = RecordingClient()
+    rows = log_rows_of(lambda logger: logger.info("the run started"))
+
+    output_writing.write_log_table(client, AS_OF, rows, output_writing.Outputs())
+    table, exists_ok = client.created[0]
+
+    assert table.time_partitioning.field == output_writing.PARTITION_FIELD
+    assert table.clustering_fields == output_writing.CLUSTERING_FIELDS
+    assert exists_ok
 
 
 def test_a_local_run_writes_the_experiments_json_to_a_directory(tmp_path):

--- a/jobs/highwind/tests/test_output_writing.py
+++ b/jobs/highwind/tests/test_output_writing.py
@@ -99,8 +99,8 @@ class FakeStorage:
         return FakeBucket(name)
 
 
-def log_rows_of(emit, as_of=AS_OF):
-    """The rows a run log makes of whatever `emit` logs through a logger of its own."""
+def run_log_of(emit, as_of=AS_OF):
+    """The run log, and its rows, for whatever `emit` logs through a logger of its own."""
     run_log = output_writing.RunLog(as_of)
     logger = logging.getLogger(__name__)
     logger.setLevel(logging.INFO)
@@ -109,7 +109,12 @@ def log_rows_of(emit, as_of=AS_OF):
         emit(logger)
     finally:
         logger.removeHandler(run_log)
-    return run_log.rows
+    return run_log, run_log.rows
+
+
+def log_rows_of(emit, as_of=AS_OF):
+    """The rows a run log makes of whatever `emit` logs through a logger of its own."""
+    return run_log_of(emit, as_of)[1]
 
 
 def write_one_run(client, outputs=None):
@@ -317,7 +322,9 @@ def test_the_columns_this_job_does_not_fill_yet_are_declared_and_left_empty():
     assert rows[0]["analysis_period"] is None
 
 
-def test_a_runs_whole_log_is_one_load_into_its_own_dates_partition():
+def test_a_runs_whole_log_is_one_appending_load_carrying_its_own_dates():
+    # Appended, and to the table rather than to a partition decorator, so the rows land in the
+    # partition their own as_of_date names.
     def emit(logger):
         logger.info("the run started")
         logger.warning("a recipe was skipped")
@@ -326,25 +333,61 @@ def test_a_runs_whole_log_is_one_load_into_its_own_dates_partition():
     client = RecordingClient()
     rows = log_rows_of(emit)
 
-    written = output_writing.write_log_table(
-        client, AS_OF, rows, output_writing.Outputs()
-    )
+    written = output_writing.write_log_table(client, rows, output_writing.Outputs())
 
     assert written == 3
-    assert [target for target, _, _ in client.loads] == [
-        f"{output_writing.LOG_TABLE}$20260801"
-    ]
+    assert [target for target, _, _ in client.loads] == [output_writing.LOG_TABLE]
     _, loaded, config = client.loads[0]
     assert len(loaded) == 3
-    assert config.write_disposition == "WRITE_TRUNCATE"
+    assert {row["as_of_date"] for row in loaded} == {AS_OF.isoformat()}
+    assert config.write_disposition == "WRITE_APPEND"
     assert config.autodetect is False
+
+
+def test_rerunning_a_date_keeps_the_earlier_attempts_log_rather_than_replacing_it():
+    # The failed attempt is usually why the rerun exists, so replacing the date's partition would
+    # delete the explanation on the way to producing the fix.
+    client = RecordingClient()
+    first = log_rows_of(lambda logger: logger.error("the first attempt died"))
+    second = log_rows_of(lambda logger: logger.info("the rerun succeeded"))
+
+    output_writing.write_log_table(client, first, output_writing.Outputs())
+    output_writing.write_log_table(client, second, output_writing.Outputs())
+
+    dispositions = {config.write_disposition for _, _, config in client.loads}
+    assert dispositions == {"WRITE_APPEND"}
+    assert all(target == output_writing.LOG_TABLE for target, _, _ in client.loads)
+    assert [row["message"] for _, loaded, _ in client.loads for row in loaded] == [
+        "the first attempt died",
+        "the rerun succeeded",
+    ]
+
+
+def test_every_row_a_run_logs_carries_that_runs_own_start_time():
+    # The only thing separating one attempt at a date from another, now that both are kept. Read
+    # off each handler rather than compared between two wall clock readings, so the test does not
+    # depend on two runs being constructed far enough apart to differ.
+    def emit(logger):
+        logger.info("the run started")
+        logger.info("the run finished")
+
+    first, first_rows = run_log_of(emit)
+    second, second_rows = run_log_of(emit)
+
+    assert {row["run_started_at"] for row in first_rows} == {
+        first.run_started_at.isoformat()
+    }
+    assert {row["run_started_at"] for row in second_rows} == {
+        second.run_started_at.isoformat()
+    }
+    assert first.run_started_at.tzinfo == datetime.timezone.utc
 
 
 def test_the_log_table_is_partitioned_and_clustered_like_the_tables_it_sits_beside():
     client = RecordingClient()
     rows = log_rows_of(lambda logger: logger.info("the run started"))
 
-    output_writing.write_log_table(client, AS_OF, rows, output_writing.Outputs())
+    output_writing.write_log_table(client, rows, output_writing.Outputs())
     table, exists_ok = client.created[0]
 
     assert table.time_partitioning.field == output_writing.PARTITION_FIELD


### PR DESCRIPTION
Because

* The job evaluates a grid of cells per experiment and writes every one of them, so a cell that failed already carries its state and its error into BigQuery where it can be queried.
* Failures that happen outside a cell have no row to land in: an experiment that fails before producing any cells, a recipe the run refuses to analyse, and the run-level account of what was consumed and what looked wrong.
* Those reach stdout only. Under Airflow that is an account nobody queries, and the run that dies partway is the one whose reason is worth the most.

This commit

* Replaces the analysis module's prints with a logger, configured once in the entry point so a container's logs read as the run report they did before.
* Adds a third table in the same dataset, written as one load job that replaces the run date's partition like the other two.
* Writes it in a `finally`, so a run that raises still records its own cause.
* Follows the same rule as the other tables about which runs may write: a filtered, sampled, local or validation run writes no partition it could replace a full run's with.
* Takes the log table's columns from the log handler Jetstream already writes through, so adopting that handler later is a swap rather than a rewrite.

`analysis_basis`, `segment` and `analysis_period` come from that handler and are declared here but always null, with the reason in each column description: those concepts are specified for this job but not yet implemented, so the column is the seam. Three columns deviate from the handler, each noted in the schema. The slug column is `experiment_slug`, matching this job's other two tables and its clustering field. The timestamp is a real `TIMESTAMP` rather than a formatted string. `exception` carries the formatted traceback rather than a tuple repr, since the line that raised is the diagnosis.
