### PR TITLE
Fetch groups from bugzilla

### DIFF
--- a/jobs/webcompat-kb/data/sql/webcompat_knowledge_base/tables/bugzilla_bugs/table.toml
+++ b/jobs/webcompat-kb/data/sql/webcompat_knowledge_base/tables/bugzilla_bugs/table.toml
@@ -54,6 +54,10 @@ mode = "NULLABLE"
 type = "STRING"
 mode = "REPEATED"
 
+[access_groups]
+type = "STRING"
+mode = "REPEATED"
+
 [url]
 type = "STRING"
 mode = "NULLABLE"

--- a/jobs/webcompat-kb/webcompat_kb/etl/bugzilla.py
+++ b/jobs/webcompat-kb/webcompat_kb/etl/bugzilla.py
@@ -139,6 +139,10 @@ class Bug(BaseModel):
     creation_time: datetime
     assigned_to: Annotated[Optional[str], unset_to_none("nobody@mozilla.org")]
     keywords: list[str]
+    # "groups" is a reserved word in BigQuery, so store it under another name
+    groups: list[str] = Field(
+        default_factory=list, serialization_alias="access_groups"
+    )
     url: Text
     user_story: Text = Field(
         validation_alias="cf_user_story", serialization_alias="user_story_raw"
@@ -198,6 +202,7 @@ class Bug(BaseModel):
                 "creation_time": row.creation_time,
                 "assigned_to": row.assigned_to,
                 "keywords": row.keywords,
+                "groups": row.access_groups,
                 "url": row.url,
                 "user_story": row.user_story_raw,
                 "last_resolved": row.resolved_time,


### PR DESCRIPTION
Our backlog bugs for autowebcompat appear stuck as it selects 3 candidate bugs and then excludes moco confidential bugs and there are 3 bugs at the top of backlog that all are moco confidential. I think storing it and excluding in the query is probably the cleanest. I'll run backfill with  --bugzilla-recreate-bugs locally once this is merged.

Checklist for reviewer:

- [ ] Commits should reference a bug or github issue, if relevant (if a bug is referenced, the pull request should include the bug number in the title)

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs

- [ ] Ensure the container image will be using permissions granted to [telemetry-airflow](https://github.com/mozilla/telemetry-airflow/) responsibly.
